### PR TITLE
Implement initial browser UI flow with menus and corridor placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cebarti Manor Prototype</title>
+    <link rel="preload" href="bg_cebartimanor_ext.png" as="image" />
+    <link rel="preload" href="bg_wallpaper.png" as="image" />
+    <link rel="preload" href="bg_room_well.png" as="image" />
+    <link rel="preload" href="bg_corridor.png" as="image" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div id="game" class="game">
+      <div id="background" class="game__background" role="img" aria-label=""></div>
+      <div id="content" class="game__content" aria-live="polite"></div>
+      <div id="fade-overlay" class="fade-overlay" aria-hidden="true"></div>
+      <div id="toast" class="toast" role="status" aria-live="polite" aria-atomic="true"></div>
+    </div>
+    <script src="main.js"></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,451 @@
+(function () {
+  const backgrounds = {
+    splash: "bg_cebartimanor_ext.png",
+    menu: "bg_wallpaper.png",
+    well: "bg_room_well.png",
+    corridor: "bg_corridor.png",
+  };
+
+  const state = {
+    currentScreen: null,
+    hasSave: false,
+    inRun: false,
+    lastRunScreen: null,
+    corridorRefreshes: 0,
+  };
+
+  const backgroundEl = document.getElementById("background");
+  const contentEl = document.getElementById("content");
+  const fadeOverlay = document.getElementById("fade-overlay");
+  const toastEl = document.getElementById("toast");
+
+  let toastTimeout = null;
+
+  const screens = {
+    splash: {
+      key: "splash",
+      background: backgrounds.splash,
+      ariaLabel: "Exterior view of Cebarti Manor at night.",
+      render(ctx) {
+        const wrapper = createElement("div", "screen screen--splash");
+        const panel = createElement("div", "panel panel--splash");
+
+        const title = createElement("h1", "screen__title", "Cebarti Manor");
+        const subtitle = createElement(
+          "p",
+          "screen__subtitle",
+          "A haunted roguelike prototype set within Helen Cebarti's cursed manor."
+        );
+        const prompt = createElement(
+          "button",
+          "button button--primary splash__cta",
+          "Click to Continue"
+        );
+
+        prompt.addEventListener("click", () => ctx.transitionTo("mainMenu"));
+        wrapper.addEventListener("click", (event) => {
+          if (event.target === wrapper) {
+            ctx.transitionTo("mainMenu");
+          }
+        });
+
+        panel.append(title, subtitle, prompt);
+        wrapper.append(panel);
+        return wrapper;
+      },
+    },
+    mainMenu: {
+      key: "mainMenu",
+      type: "menu",
+      ariaLabel: "Wallpaper from inside Cebarti Manor, used for menus.",
+      render(ctx) {
+        const wrapper = createElement("div", "screen screen--menu");
+        const panel = createElement("div", "panel panel--menu");
+
+        const title = createElement("h1", "screen__title", "Cebarti Manor");
+        const subtitle = createElement(
+          "p",
+          "screen__subtitle",
+          "Choose how you will haunt the manor."
+        );
+
+        const menu = createElement("div", "menu");
+
+        const continueBtn = createElement(
+          "button",
+          "button menu__button",
+          "Continue Run"
+        );
+        continueBtn.style.display = ctx.state.hasSave ? "block" : "none";
+        continueBtn.addEventListener("click", () => {
+          if (!ctx.state.hasSave || !ctx.state.lastRunScreen) {
+            ctx.showToast("No run to continue yet.");
+            return;
+          }
+          ctx.transitionTo(ctx.state.lastRunScreen);
+        });
+
+        const newRunBtn = createElement(
+          "button",
+          "button menu__button",
+          "New Run"
+        );
+        newRunBtn.addEventListener("click", () => {
+          ctx.state.inRun = true;
+          ctx.state.hasSave = false;
+          ctx.state.corridorRefreshes = 0;
+          ctx.transitionTo("well");
+        });
+
+        const bestiaryBtn = createElement(
+          "button",
+          "button menu__button",
+          "Beastiary"
+        );
+        bestiaryBtn.addEventListener("click", () => ctx.transitionTo("bestiary"));
+
+        const settingsBtn = createElement(
+          "button",
+          "button menu__button",
+          "Settings"
+        );
+        settingsBtn.addEventListener("click", () => ctx.transitionTo("settings"));
+
+        const exitBtn = createElement("button", "button menu__button", "Exit");
+        exitBtn.addEventListener("click", () => {
+          ctx.showToast("Exit will be available in the desktop build.");
+        });
+
+        menu.append(continueBtn, newRunBtn, bestiaryBtn, settingsBtn, exitBtn);
+        panel.append(title, subtitle, menu);
+        wrapper.append(panel);
+        return wrapper;
+      },
+    },
+    bestiary: {
+      key: "bestiary",
+      type: "menu",
+      ariaLabel: "Wallpaper from inside Cebarti Manor, used for menus.",
+      render(ctx) {
+        const wrapper = createElement("div", "screen screen--menu");
+        const panel = createElement("div", "panel panel--menu");
+
+        const title = createElement("h2", "screen__title", "Beastiary");
+        const subtitle = createElement(
+          "p",
+          "screen__subtitle",
+          "Catalog the manor's residents. Bestiary entries will unlock as development continues."
+        );
+
+        const backButton = createElement(
+          "button",
+          "button",
+          "Back to Menu"
+        );
+        backButton.addEventListener("click", () => ctx.transitionTo("mainMenu"));
+
+        panel.append(title, subtitle, backButton);
+        wrapper.append(panel);
+        return wrapper;
+      },
+    },
+    settings: {
+      key: "settings",
+      type: "menu",
+      ariaLabel: "Wallpaper from inside Cebarti Manor, used for menus.",
+      render(ctx) {
+        const wrapper = createElement("div", "screen screen--menu");
+        const panel = createElement("div", "panel panel--menu");
+
+        const title = createElement("h2", "screen__title", "Settings");
+        const subtitle = createElement(
+          "p",
+          "screen__subtitle",
+          "Configure your haunting experience. Options will arrive in future updates."
+        );
+
+        const backButton = createElement(
+          "button",
+          "button",
+          "Back to Menu"
+        );
+        backButton.addEventListener("click", () => ctx.transitionTo("mainMenu"));
+
+        panel.append(title, subtitle, backButton);
+        wrapper.append(panel);
+        return wrapper;
+      },
+    },
+    well: {
+      key: "well",
+      background: backgrounds.well,
+      ariaLabel: "The Styx well inside Cebarti Manor.",
+      checkpoint: true,
+      render(ctx) {
+        const wrapper = createElement("div", "screen screen--well");
+
+        const title = createElement("h2", "screen__title", "The Styx Well");
+        const subtitle = createElement(
+          "p",
+          "screen__subtitle",
+          "Draft three memories to define this run's starting action pool."
+        );
+
+        const buttonRow = createElement("div", "button-row");
+        for (let i = 0; i < 3; i += 1) {
+          const draftButton = createElement(
+            "button",
+            "button",
+            "Draft a Memory"
+          );
+          draftButton.addEventListener("click", () => {
+            ctx.showToast("Memory drafting will be implemented soon.");
+          });
+          buttonRow.appendChild(draftButton);
+        }
+
+        const footer = createElement("div", "screen-footer");
+        const continueButton = createElement(
+          "button",
+          "button button--primary",
+          "Continue"
+        );
+        continueButton.addEventListener("click", async () => {
+          ctx.state.corridorRefreshes = 0;
+          ctx.state.lastRunScreen = "corridor";
+          await ctx.transitionTo("corridor");
+          ctx.showToast("You ascend into the corridor.");
+        });
+        footer.appendChild(continueButton);
+
+        wrapper.append(title, subtitle, buttonRow, footer);
+        return wrapper;
+      },
+    },
+    corridor: {
+      key: "corridor",
+      background: backgrounds.corridor,
+      ariaLabel: "A corridor within Cebarti Manor awaiting door choices.",
+      checkpoint: true,
+      render(ctx) {
+        const wrapper = createElement("div", "screen screen--corridor");
+
+        const title = createElement("h2", "screen__title", "The Corridor");
+        const refreshCount = ctx.state.corridorRefreshes;
+        const descriptionText =
+          refreshCount === 0
+            ? "Three doors shimmer ahead. Choose your path or continue down the corridor."
+            : `The manor shifts around you. Corridor reshaped ${refreshCount} time${
+                refreshCount === 1 ? "" : "s"
+              }.`;
+        const subtitle = createElement("p", "screen__subtitle", descriptionText);
+
+        const doorMap = createElement("div", "door-map");
+        const placeholders = [
+          {
+            label: "Future yellow door",
+            classes: "door-slot door-slot--yellow door-slot--left",
+          },
+          {
+            label: "Future blue door",
+            classes: "door-slot door-slot--blue door-slot--center",
+          },
+          {
+            label: "Future red door",
+            classes: "door-slot door-slot--red door-slot--right",
+          },
+        ];
+        placeholders.forEach((placeholder) => {
+          const slot = createElement("div", placeholder.classes);
+          slot.dataset.label = placeholder.label;
+          const hiddenLabel = createElement("span", "sr-only", placeholder.label);
+          slot.appendChild(hiddenLabel);
+          doorMap.appendChild(slot);
+        });
+
+        const footer = createElement("div", "screen-footer");
+        const continueButton = createElement(
+          "button",
+          "button button--primary",
+          "Continue Down the Corridor"
+        );
+        continueButton.addEventListener("click", async () => {
+          ctx.state.corridorRefreshes += 1;
+          ctx.state.lastRunScreen = "corridor";
+          await ctx.transitionTo("corridor", { refresh: true });
+          ctx.showToast("The corridor rearranges itself.");
+        });
+        footer.appendChild(continueButton);
+
+        wrapper.append(title, subtitle, doorMap, footer);
+        return wrapper;
+      },
+    },
+  };
+
+  function createElement(tag, className, textContent) {
+    const element = document.createElement(tag);
+    if (className) {
+      element.className = className;
+    }
+    if (textContent !== undefined) {
+      element.textContent = textContent;
+    }
+    return element;
+  }
+
+  function getBackgroundForScreen(screenDef) {
+    if (screenDef.background) {
+      return screenDef.background;
+    }
+    if (screenDef.type === "menu") {
+      return backgrounds.menu;
+    }
+    return backgrounds.menu;
+  }
+
+  function setBackground(screenDef) {
+    const image = getBackgroundForScreen(screenDef);
+    if (backgroundEl.dataset.bg !== image) {
+      backgroundEl.style.backgroundImage = `url("${image}")`;
+      backgroundEl.dataset.bg = image;
+    }
+    if (screenDef.ariaLabel) {
+      backgroundEl.setAttribute("aria-label", screenDef.ariaLabel);
+    }
+  }
+
+  function showToast(message, { duration = 3600 } = {}) {
+    if (!toastEl) return;
+    toastEl.textContent = message;
+    toastEl.classList.add("toast--visible");
+    if (toastTimeout) {
+      clearTimeout(toastTimeout);
+    }
+    toastTimeout = window.setTimeout(() => {
+      toastEl.classList.remove("toast--visible");
+    }, duration);
+  }
+
+  function fadeToBlack() {
+    return new Promise((resolve) => {
+      if (!fadeOverlay) {
+        resolve();
+        return;
+      }
+      fadeOverlay.classList.add("visible");
+      requestAnimationFrame(() => {
+        fadeOverlay.classList.add("opaque");
+      });
+
+      const cleanup = () => {
+        window.clearTimeout(fallback);
+        fadeOverlay.removeEventListener("transitionend", onTransitionEnd);
+        resolve();
+      };
+
+      const onTransitionEnd = (event) => {
+        if (event.target === fadeOverlay) {
+          cleanup();
+        }
+      };
+
+      const fallback = window.setTimeout(cleanup, 650);
+      fadeOverlay.addEventListener("transitionend", onTransitionEnd);
+    });
+  }
+
+  function fadeFromBlack() {
+    return new Promise((resolve) => {
+      if (!fadeOverlay) {
+        resolve();
+        return;
+      }
+
+      const cleanup = () => {
+        window.clearTimeout(fallback);
+        fadeOverlay.removeEventListener("transitionend", onTransitionEnd);
+        fadeOverlay.classList.remove("visible");
+        resolve();
+      };
+
+      const onTransitionEnd = (event) => {
+        if (event.target === fadeOverlay) {
+          cleanup();
+        }
+      };
+
+      const fallback = window.setTimeout(cleanup, 650);
+      fadeOverlay.classList.remove("opaque");
+      fadeOverlay.addEventListener("transitionend", onTransitionEnd);
+    });
+  }
+
+  async function transitionTo(screenKey, options = {}) {
+    const screenDef = screens[screenKey];
+    if (!screenDef) {
+      throw new Error(`Unknown screen: ${screenKey}`);
+    }
+    if (state.currentScreen === screenKey && !options.refresh) {
+      return;
+    }
+
+    await fadeToBlack();
+    renderScreen(screenKey, options);
+    await fadeFromBlack();
+  }
+
+  function renderScreen(screenKey, options = {}) {
+    const screenDef = screens[screenKey];
+    if (!screenDef) return;
+
+    const context = {
+      state,
+      transitionTo,
+      showToast,
+      options,
+    };
+
+    const screenContent = screenDef.render(context);
+    contentEl.replaceChildren(screenContent);
+    setBackground(screenDef);
+
+    state.currentScreen = screenKey;
+    if (screenDef.checkpoint) {
+      state.hasSave = true;
+      state.lastRunScreen = screenKey;
+    }
+
+    if (screenKey === "corridor") {
+      state.inRun = true;
+    }
+  }
+
+  function preloadImages(imageList) {
+    imageList.forEach((src) => {
+      const img = new Image();
+      img.src = src;
+    });
+  }
+
+  function initialize() {
+    const initialScreen = screens.splash;
+    setBackground(initialScreen);
+    const splashContent = initialScreen.render({
+      state,
+      transitionTo,
+      showToast,
+      options: {},
+    });
+    contentEl.appendChild(splashContent);
+    state.currentScreen = "splash";
+
+    const imagesToPreload = new Set();
+    Object.values(screens).forEach((screen) => {
+      imagesToPreload.add(getBackgroundForScreen(screen));
+    });
+    preloadImages(Array.from(imagesToPreload));
+  }
+
+  initialize();
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,347 @@
+:root {
+  --font-heading: "Cinzel", "Garamond", "Georgia", serif;
+  --font-body: "Cormorant Garamond", "Georgia", serif;
+  --color-text: #f7f3eb;
+  --color-muted: rgba(247, 243, 235, 0.7);
+  --color-accent: #d6b370;
+  --color-accent-dark: #8b6837;
+  --color-panel: rgba(8, 4, 2, 0.6);
+  --shadow-heavy: 0 12px 40px rgba(0, 0, 0, 0.6);
+  --transition-duration: 420ms;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: var(--font-body);
+  background: #050302;
+  color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: var(--font-heading);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+button {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.game {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  color: var(--color-text);
+}
+
+.game__background {
+  position: absolute;
+  inset: 0;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+  z-index: 0;
+}
+
+.game__background::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      rgba(10, 5, 1, 0.75),
+      rgba(10, 5, 1, 0.4) 35%,
+      rgba(4, 2, 1, 0.75)
+    );
+  pointer-events: none;
+}
+
+.game__content {
+  position: relative;
+  z-index: 1;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: clamp(1.5rem, 4vw, 3.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.screen {
+  position: relative;
+  max-width: 960px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: clamp(1rem, 2vw, 2rem);
+  pointer-events: auto;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.85);
+}
+
+.screen__title {
+  font-size: clamp(2rem, 6vw, 3.75rem);
+  color: var(--color-text);
+}
+
+.screen__subtitle {
+  font-size: clamp(1rem, 2vw, 1.35rem);
+  color: var(--color-muted);
+  max-width: 720px;
+}
+
+.panel {
+  background: var(--color-panel);
+  padding: clamp(1.5rem, 3vw, 2.75rem);
+  border: 1px solid rgba(214, 179, 112, 0.4);
+  box-shadow: var(--shadow-heavy);
+  backdrop-filter: blur(3px);
+  border-radius: 18px;
+}
+
+.menu {
+  width: min(360px, 90%);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.menu__button {
+  width: 100%;
+}
+
+.button {
+  appearance: none;
+  border: 1px solid rgba(214, 179, 112, 0.5);
+  background: rgba(16, 9, 5, 0.75);
+  color: var(--color-text);
+  padding: 0.9rem 1.25rem;
+  border-radius: 12px;
+  font-size: clamp(0.9rem, 1.7vw, 1.05rem);
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease, border-color 160ms ease;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.button:hover,
+.button:focus-visible {
+  background: rgba(35, 20, 10, 0.85);
+  border-color: rgba(214, 179, 112, 0.85);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.button[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.button--primary {
+  background: rgba(214, 179, 112, 0.9);
+  color: #241305;
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  background: rgba(237, 205, 156, 0.95);
+  border-color: rgba(255, 233, 189, 0.9);
+}
+
+.screen-footer {
+  position: absolute;
+  right: clamp(1.25rem, 4vw, 3rem);
+  bottom: clamp(1.25rem, 4vw, 3rem);
+}
+
+.screen-footer .button {
+  min-width: 220px;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.button-row .button {
+  min-width: 180px;
+}
+
+.splash__cta {
+  padding: clamp(0.9rem, 1.8vw, 1.2rem) clamp(1.4rem, 3vw, 2rem);
+}
+
+.door-map {
+  position: relative;
+  width: min(900px, 88vw);
+  height: min(520px, 60vh);
+}
+
+.door-slot {
+  position: absolute;
+  width: clamp(120px, 12vw, 180px);
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: 4px solid rgba(0, 0, 0, 0.6);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+}
+
+.door-slot::after {
+  content: attr(data-label);
+  position: absolute;
+  left: 50%;
+  bottom: -2.6rem;
+  transform: translateX(-50%);
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  pointer-events: none;
+}
+
+.door-slot--left {
+  top: 36%;
+  left: 12%;
+}
+
+.door-slot--center {
+  top: 28%;
+  left: 44%;
+}
+
+.door-slot--right {
+  top: 36%;
+  right: 12%;
+}
+
+.door-slot--yellow {
+  background: radial-gradient(circle at 30% 30%, #fff8c2, #bfa12c 68%, #6a5207 100%);
+}
+
+.door-slot--blue {
+  background: radial-gradient(circle at 30% 30%, #f0f7ff, #3b74b8 70%, #15385d 100%);
+}
+
+.door-slot--red {
+  background: radial-gradient(circle at 30% 30%, #ffe6e0, #b43a32 68%, #5a0909 100%);
+}
+
+.fade-overlay {
+  position: absolute;
+  inset: 0;
+  background: #000;
+  z-index: 4;
+  opacity: 0;
+  transition: opacity var(--transition-duration) ease;
+  pointer-events: none;
+}
+
+.fade-overlay.visible {
+  pointer-events: auto;
+}
+
+.fade-overlay.opaque {
+  opacity: 1;
+}
+
+.toast {
+  position: absolute;
+  top: 1.5rem;
+  left: 50%;
+  transform: translate(-50%, -30%);
+  background: rgba(20, 11, 5, 0.85);
+  color: var(--color-text);
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(214, 179, 112, 0.45);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transition: opacity 220ms ease, transform 220ms ease;
+  pointer-events: none;
+  z-index: 5;
+  min-width: 200px;
+  text-align: center;
+}
+
+.toast--visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .door-slot::after {
+    display: none;
+  }
+
+  .door-slot--left,
+  .door-slot--center,
+  .door-slot--right {
+    position: static;
+  }
+
+  .door-map {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    height: auto;
+  }
+
+  .door-slot {
+    position: static;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add the HTML shell that preloads key backgrounds and exposes the game, fade, and toast layers
- create gothic-inspired styling for menus, door placeholders, fade transitions, and responsive layouts
- build the JavaScript screen manager with splash, main menu, well, corridor flows, and reusable fade transitions

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c9b467b070832cbb38404ba68135df