### PR TITLE
Implement random room traversal and victory flow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -207,17 +207,23 @@ button {
   height: min(520px, 60vh);
 }
 
-.door-slot {
+.door-button {
   position: absolute;
   width: clamp(120px, 12vw, 180px);
   aspect-ratio: 1 / 1;
   border-radius: 50%;
   border: 4px solid rgba(0, 0, 0, 0.6);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
-  pointer-events: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease,
+    filter 160ms ease;
 }
 
-.door-slot::after {
+.door-button::after {
   content: attr(data-label);
   position: absolute;
   left: 50%;
@@ -230,31 +236,85 @@ button {
   pointer-events: none;
 }
 
-.door-slot--left {
+.door-button::before {
+  content: "";
+  position: absolute;
+  inset: 6%;
+  border-radius: 50%;
+  box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.55);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.door-button:focus-visible {
+  outline: 3px solid rgba(255, 233, 189, 0.85);
+  outline-offset: 4px;
+}
+
+.door-button:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.6);
+  filter: brightness(1.05);
+}
+
+.door-button:active {
+  transform: translateY(0);
+}
+
+.door-button:disabled {
+  cursor: default;
+  opacity: 0.75;
+  transform: none;
+}
+
+.door-button--left {
   top: 36%;
   left: 12%;
 }
 
-.door-slot--center {
+.door-button--center {
   top: 28%;
   left: 44%;
 }
 
-.door-slot--right {
+.door-button--right {
   top: 36%;
   right: 12%;
 }
 
-.door-slot--yellow {
+.door-button--amber {
   background: radial-gradient(circle at 30% 30%, #fff8c2, #bfa12c 68%, #6a5207 100%);
 }
 
-.door-slot--blue {
+.door-button--azure {
   background: radial-gradient(circle at 30% 30%, #f0f7ff, #3b74b8 70%, #15385d 100%);
 }
 
-.door-slot--red {
+.door-button--crimson {
   background: radial-gradient(circle at 30% 30%, #ffe6e0, #b43a32 68%, #5a0909 100%);
+}
+
+.door-button--verdant {
+  background: radial-gradient(circle at 30% 30%, #e9fbe8, #4f9c55 70%, #1f5027 100%);
+}
+
+.door-button--violet {
+  background: radial-gradient(circle at 30% 30%, #f3e8ff, #7b52b7 70%, #33124f 100%);
+}
+
+.run-tracker {
+  position: absolute;
+  top: clamp(1rem, 4vw, 2.5rem);
+  right: clamp(1rem, 4vw, 2.5rem);
+  background: rgba(10, 5, 2, 0.68);
+  border: 1px solid rgba(214, 179, 112, 0.45);
+  border-radius: 999px;
+  padding: 0.45rem 1.15rem;
+  font-size: clamp(0.8rem, 1.5vw, 0.95rem);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  pointer-events: none;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
 }
 
 .fade-overlay {
@@ -312,13 +372,13 @@ button {
 }
 
 @media (max-width: 720px) {
-  .door-slot::after {
+  .door-button::after {
     display: none;
   }
 
-  .door-slot--left,
-  .door-slot--center,
-  .door-slot--right {
+  .door-button--left,
+  .door-button--center,
+  .door-button--right {
     position: static;
   }
 
@@ -330,7 +390,7 @@ button {
     height: auto;
   }
 
-  .door-slot {
+  .door-button {
     position: static;
   }
 }


### PR DESCRIPTION
## Summary
- add a randomized pool of unique room backgrounds that are removed once visited and persist through corridor refreshes
- build dedicated room, foyer, and victory screens with run tracking, boss transition, and save/reset handling
- refresh corridor door UI with interactive door buttons, run progress badge, and responsive styling updates

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9c71ff198832c91906c3e685ffde4