### PR TITLE
Refine corridor layout and label encounter doors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -92,13 +92,14 @@ button {
 .screen {
   position: relative;
   max-width: 960px;
-  width: 100%;
+  width: min(960px, 100%);
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: clamp(1rem, 2vw, 2rem);
+  gap: clamp(1.25rem, 3vw, 2.5rem);
   pointer-events: auto;
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.85);
 }
@@ -111,7 +112,10 @@ button {
 .screen__subtitle {
   font-size: clamp(1rem, 2vw, 1.35rem);
   color: var(--color-muted);
-  max-width: 720px;
+  max-width: clamp(460px, 70vw, 720px);
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.7;
 }
 
 .panel {
@@ -142,6 +146,11 @@ button {
   padding: 0.9rem 1.25rem;
   border-radius: 12px;
   font-size: clamp(0.9rem, 1.7vw, 1.05rem);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  text-align: center;
   cursor: pointer;
   transition: background 160ms ease, transform 160ms ease, border-color 160ms ease;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
@@ -177,13 +186,17 @@ button {
 }
 
 .screen-footer {
-  position: absolute;
-  right: clamp(1.25rem, 4vw, 3rem);
-  bottom: clamp(1.25rem, 4vw, 3rem);
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  margin-top: clamp(1.5rem, 4vw, 2.75rem);
 }
 
 .screen-footer .button {
-  min-width: 220px;
+  min-width: clamp(180px, 50vw, 260px);
 }
 
 .button-row {
@@ -202,38 +215,39 @@ button {
 }
 
 .door-map {
-  position: relative;
-  width: min(900px, 88vw);
-  height: min(520px, 60vh);
+  width: min(820px, 92vw);
+  margin-inline: auto;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(clamp(160px, 24vw, 220px), 1fr)
+  );
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: start;
+  justify-items: center;
+  background: rgba(10, 5, 2, 0.6);
+  border: 1px solid rgba(214, 179, 112, 0.35);
+  border-radius: 26px;
+  box-shadow: var(--shadow-heavy);
+  backdrop-filter: blur(4px);
 }
 
 .door-button {
-  position: absolute;
-  width: clamp(120px, 12vw, 180px);
+  position: relative;
+  width: clamp(120px, 18vw, 180px);
   aspect-ratio: 1 / 1;
   border-radius: 50%;
-  border: 4px solid rgba(0, 0, 0, 0.6);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
+  border: 3px solid rgba(0, 0, 0, 0.65);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.55);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   background: rgba(0, 0, 0, 0.45);
-  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease,
-    filter 160ms ease;
-}
-
-.door-button::after {
-  content: attr(data-label);
-  position: absolute;
-  left: 50%;
-  bottom: -2.6rem;
-  transform: translateX(-50%);
-  font-size: 0.8rem;
-  color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  pointer-events: none;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease,
+    filter 180ms ease;
+  isolation: isolate;
 }
 
 .door-button::before {
@@ -252,34 +266,19 @@ button {
 }
 
 .door-button:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.6);
-  filter: brightness(1.05);
+  transform: translateY(-6px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.6);
+  filter: brightness(1.08);
 }
 
 .door-button:active {
-  transform: translateY(0);
+  transform: translateY(-2px);
 }
 
 .door-button:disabled {
   cursor: default;
-  opacity: 0.75;
+  opacity: 0.7;
   transform: none;
-}
-
-.door-button--left {
-  top: 36%;
-  left: 12%;
-}
-
-.door-button--center {
-  top: 28%;
-  left: 44%;
-}
-
-.door-button--right {
-  top: 36%;
-  right: 12%;
 }
 
 .door-button--amber {
@@ -300,6 +299,39 @@ button {
 
 .door-button--violet {
   background: radial-gradient(circle at 30% 30%, #f3e8ff, #7b52b7 70%, #33124f 100%);
+}
+
+.door-button--umbra {
+  background: radial-gradient(circle at 30% 30%, #f5ecff, #59468d 64%, #120825 100%);
+}
+
+.door-button--aether {
+  background: radial-gradient(circle at 30% 30%, #e8fbff, #3c8f9b 68%, #0a343d 100%);
+}
+
+.door-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: clamp(160px, 24vw, 220px);
+  text-align: center;
+}
+
+.door-option__label {
+  font-family: var(--font-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: clamp(0.72rem, 1.3vw, 0.85rem);
+  color: var(--color-muted);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.65);
+}
+
+.door-option__detail {
+  font-size: clamp(0.7rem, 1.35vw, 0.88rem);
+  color: rgba(247, 243, 235, 0.72);
+  line-height: 1.5;
+  max-width: 18ch;
 }
 
 .run-tracker {
@@ -372,26 +404,18 @@ button {
 }
 
 @media (max-width: 720px) {
-  .door-button::after {
-    display: none;
-  }
-
-  .door-button--left,
-  .door-button--center,
-  .door-button--right {
-    position: static;
-  }
-
   .door-map {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    height: auto;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    padding: clamp(1.25rem, 5vw, 1.75rem);
+    gap: clamp(1.25rem, 4vw, 2rem);
   }
 
-  .door-button {
-    position: static;
+  .door-option {
+    max-width: 220px;
+  }
+
+  .screen-footer .button {
+    min-width: clamp(180px, 70vw, 240px);
   }
 }
 


### PR DESCRIPTION
## Summary
- present corridor doors in a centered grid with dedicated wrappers and supporting text for each option
- label every corridor door with a unique encounter category (Combat, Elite, Boss, Recovery, Treasure, Merchant, Event)
- refresh shared styling so screen footers, buttons, and door visuals align cleanly across layouts

## Testing
- not run (static HTML/CSS project)


------
https://chatgpt.com/codex/tasks/task_e_68c9d0f821a4832c80cbadb663931928