### PR TITLE
Add enhanced door mechanics and restore sprite displays

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -343,51 +343,202 @@ button {
 }
 
 .door-button {
+  --door-glow: rgba(214, 179, 112, 0.32);
+  --door-highlight: rgba(255, 224, 173, 0.38);
   position: relative;
-  width: clamp(120px, 18vw, 180px);
-  aspect-ratio: 1 / 1;
-  border-radius: 50%;
-  border: 3px solid rgba(0, 0, 0, 0.65);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.55);
+  width: clamp(140px, 22vw, 220px);
+  aspect-ratio: 3 / 5;
+  border: none;
+  background: none;
+  padding: 0;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.45);
-  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease,
-    filter 180ms ease;
+  transition: transform 180ms ease;
   isolation: isolate;
 }
 
-.door-button::before {
-  content: "";
+.door-button__frame {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(8, 4, 2, 0.65);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+  transition: box-shadow 180ms ease, transform 180ms ease;
+  transform: translateY(var(--door-raise, 0px));
+}
+
+.door-button__sprite {
   position: absolute;
-  inset: 6%;
-  border-radius: 50%;
-  box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.55);
-  opacity: 0.8;
+  inset: 0;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-image: url("objspr_doors_door.png");
+  filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.65));
+  transition: filter 180ms ease;
+}
+
+.door-button__shine {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse at 50% 18%,
+    rgba(255, 228, 184, 0.25),
+    transparent 60%
+  );
+  opacity: 0;
+  transition: opacity 200ms ease;
   pointer-events: none;
 }
 
+.door-button__icon {
+  position: absolute;
+  top: 8%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 58%;
+  pointer-events: none;
+  transition: filter 200ms ease, transform 200ms ease;
+}
+
+.door-button__lock {
+  position: absolute;
+  left: 50%;
+  bottom: 20%;
+  width: 32%;
+  transform: translate(-50%, 10%) scale(0.85);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
 .door-button:focus-visible {
-  outline: 3px solid rgba(255, 233, 189, 0.85);
-  outline-offset: 4px;
+  outline: 3px solid rgba(255, 233, 189, 0.9);
+  outline-offset: 6px;
 }
 
-.door-button:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.6);
-  filter: brightness(1.08);
+.door-button:hover .door-button__frame,
+.door-button:focus-visible .door-button__frame {
+  --door-raise: -6px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.6),
+    0 0 24px var(--door-glow);
 }
 
-.door-button:active {
-  transform: translateY(-2px);
+.door-button:hover .door-button__sprite,
+.door-button:focus-visible .door-button__sprite {
+  filter: drop-shadow(0 8px 18px var(--door-highlight));
+}
+
+.door-button:hover .door-button__icon,
+.door-button:focus-visible .door-button__icon {
+  filter: brightness(1.15) saturate(1.1);
+  transform: translate(-50%, -6%) scale(1.04);
+}
+
+.door-button:hover .door-button__shine,
+.door-button:focus-visible .door-button__shine {
+  opacity: 1;
+}
+
+.door-button:active .door-button__frame {
+  --door-raise: -2px;
 }
 
 .door-button:disabled {
   cursor: default;
-  opacity: 0.7;
-  transform: none;
+  opacity: 0.75;
+}
+
+.door-button:disabled .door-button__frame {
+  --door-raise: 0px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4);
+}
+
+.door-button:disabled .door-button__icon {
+  filter: grayscale(0.15);
+}
+
+.door-button--enhanced .door-button__frame {
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.6), 0 0 28px var(--door-glow);
+}
+
+.door-button--enhanced .door-button__shine {
+  opacity: 0.65;
+}
+
+.door-button--locked .door-button__sprite {
+  filter: saturate(0.8) drop-shadow(0 6px 14px rgba(0, 0, 0, 0.7));
+}
+
+.door-button--locked .door-button__frame {
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.55),
+    0 0 18px rgba(120, 100, 80, 0.4);
+}
+
+.door-button--locked .door-button__lock {
+  opacity: 1;
+  transform: translate(-50%, -6%) scale(1);
+}
+
+.door-button--shake .door-button__frame {
+  animation: door-shake 360ms ease;
+}
+
+@keyframes door-shake {
+  0% {
+    transform: translateY(var(--door-raise, 0px)) translateX(0);
+  }
+  20% {
+    transform: translateY(var(--door-raise, 0px)) translateX(-6px);
+  }
+  40% {
+    transform: translateY(var(--door-raise, 0px)) translateX(6px);
+  }
+  60% {
+    transform: translateY(var(--door-raise, 0px)) translateX(-4px);
+  }
+  80% {
+    transform: translateY(var(--door-raise, 0px)) translateX(4px);
+  }
+  100% {
+    transform: translateY(var(--door-raise, 0px)) translateX(0);
+  }
+}
+
+.door-button--crimson {
+  --door-glow: rgba(198, 68, 78, 0.55);
+  --door-highlight: rgba(255, 176, 186, 0.62);
+}
+
+.door-button--violet {
+  --door-glow: rgba(146, 84, 196, 0.5);
+  --door-highlight: rgba(210, 176, 255, 0.58);
+}
+
+.door-button--umbra {
+  --door-glow: rgba(98, 90, 152, 0.55);
+  --door-highlight: rgba(184, 172, 236, 0.58);
+}
+
+.door-button--verdant {
+  --door-glow: rgba(88, 148, 104, 0.55);
+  --door-highlight: rgba(178, 238, 201, 0.56);
+}
+
+.door-button--amber {
+  --door-glow: rgba(214, 163, 96, 0.55);
+  --door-highlight: rgba(255, 210, 150, 0.56);
+}
+
+.door-button--azure {
+  --door-glow: rgba(96, 152, 214, 0.5);
+  --door-highlight: rgba(180, 218, 255, 0.6);
+}
+
+.door-button--aether {
+  --door-glow: rgba(156, 174, 214, 0.5);
+  --door-highlight: rgba(210, 228, 255, 0.56);
 }
 
 .run-tracker {
@@ -694,12 +845,30 @@ button {
   transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
+.codex-icon--has-image {
+  padding: 4px;
+}
+
+.codex-icon__image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.55));
+  pointer-events: none;
+  transition: filter 160ms ease;
+}
+
 .codex-icon:hover,
 .codex-icon:focus-visible {
   transform: translateY(-2px);
   border-color: rgba(214, 179, 112, 0.75);
   outline: none;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.codex-icon:hover .codex-icon__image,
+.codex-icon:focus-visible .codex-icon__image {
+  filter: brightness(1.1) drop-shadow(0 6px 14px rgba(0, 0, 0, 0.6));
 }
 
 .codex-icon.is-selected {
@@ -747,6 +916,24 @@ button {
 
 .codex-detail__icon--relic {
   background: rgba(18, 10, 6, 0.7);
+}
+
+.codex-detail__icon--has-image {
+  width: auto;
+  height: auto;
+  background: rgba(12, 6, 3, 0.6);
+  border: 1px solid rgba(214, 179, 112, 0.35);
+  padding: 0.5rem;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+}
+
+.codex-detail__image {
+  width: clamp(92px, 20vw, 136px);
+  max-width: 100%;
+  height: auto;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.55));
 }
 
 .codex-icon--anger,
@@ -798,6 +985,7 @@ button {
   letter-spacing: 0.08em;
   border: 1px solid rgba(0, 0, 0, 0.45);
   box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
 }
 
 .codex-detail__name {
@@ -1168,6 +1356,25 @@ button {
   font-size: clamp(0.72rem, 1.3vw, 0.85rem);
   color: var(--color-muted);
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.65);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.door-option__label--locked {
+  color: var(--color-text);
+}
+
+.door-option__badge {
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(214, 179, 112, 0.55);
+  background: rgba(214, 179, 112, 0.18);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  color: var(--color-accent);
+  text-transform: uppercase;
+  font-family: var(--font-heading);
 }
 
 .door-option__detail {
@@ -1537,18 +1744,42 @@ button {
 }
 
 .combatant-card__avatar {
-  width: 120px;
-  height: 120px;
-  border-radius: 30%;
-  background: radial-gradient(circle at 30% 30%, #c8e7ff, #426d9d);
+  position: relative;
+  width: clamp(120px, 22vw, 160px);
+  height: clamp(120px, 22vw, 160px);
+  border-radius: 20px;
+  background: rgba(10, 6, 4, 0.75);
+  border: 1px solid rgba(214, 179, 112, 0.28);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
+  overflow: hidden;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
+}
+
+.combatant-card__avatar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 50% 20%,
+    rgba(255, 228, 184, 0.18),
+    transparent 65%
+  );
+  pointer-events: none;
 }
 
 .combatant-card--enemy .combatant-card__avatar {
-  background: radial-gradient(circle at 30% 30%, #ffcbc9, #772a3d);
+  background: rgba(44, 10, 20, 0.75);
+  border-color: rgba(214, 112, 136, 0.35);
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.55);
+}
+
+.combatant-card__sprite {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.6));
 }
 
 .combatant-card__name {


### PR DESCRIPTION
## Summary
- replace the corridor’s door UI with sprite-based buttons, lock handling, and support for the new Manor Key consumable that can unlock enhanced rooms
- boost rewards in enhanced rooms by increasing gold payouts and forcing memory, relic, or consumable drops into draft selections with a bonus consumable draft when appropriate
- restore sprite rendering in the codex and combat panels so bestiary entries and combatants display their artwork, updating the accompanying styling for the new art-first presentation

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb25c3d040832c99754aee18a9de0f