### PR TITLE
Refine menu and bestiary layouts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,12 @@ button {
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.85);
 }
 
+.screen--bestiary {
+  max-width: none;
+  width: min(1120px, 96vw);
+  gap: clamp(1.25rem, 2.5vw, 1.75rem);
+}
+
 .screen__title {
   font-size: clamp(2rem, 6vw, 3.75rem);
   color: var(--color-text);
@@ -118,6 +124,10 @@ button {
   line-height: 1.7;
 }
 
+.screen--bestiary .screen__subtitle {
+  max-width: 52ch;
+}
+
 .panel {
   background: var(--color-panel);
   padding: clamp(1.5rem, 3vw, 2.75rem);
@@ -127,11 +137,36 @@ button {
   border-radius: 18px;
 }
 
+
 .menu {
   width: min(360px, 90%);
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.panel--menu {
+  width: min(520px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  text-align: center;
+}
+
+.screen--menu:not(.screen--bestiary) {
+  max-width: none;
+  width: min(520px, 92vw);
+}
+
+.screen--menu:not(.screen--bestiary) .screen__subtitle {
+  max-width: 34ch;
+}
+
+.screen--menu:not(.screen--bestiary) .menu {
+  width: min(360px, 100%);
+  gap: clamp(0.85rem, 2.5vw, 1.15rem);
+  align-items: stretch;
 }
 
 .menu__button {
@@ -197,6 +232,10 @@ button {
 
 .screen-footer .button {
   min-width: clamp(180px, 50vw, 260px);
+}
+
+.screen--bestiary .screen-footer {
+  margin-top: clamp(1.1rem, 2.5vw, 1.6rem);
 }
 
 .room-scene {
@@ -707,6 +746,68 @@ button {
   text-align: left;
 }
 
+.screen--bestiary .panel--codex {
+  width: min(1080px, 95vw);
+  gap: clamp(1.5rem, 3vw, 2rem);
+  padding: clamp(2rem, 4vw, 2.75rem);
+}
+
+.screen--bestiary .codex-panel__content--screen {
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.35rem, 3vw, 1.75rem);
+  overflow: visible;
+}
+
+.screen--bestiary .codex {
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 3.5vw, 2.5rem);
+  align-items: start;
+}
+
+.screen--bestiary .codex-detail {
+  align-self: stretch;
+}
+
+.screen--bestiary .codex__sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+  align-items: stretch;
+}
+
+.screen--bestiary .codex-section {
+  background: rgba(10, 5, 2, 0.45);
+  border: 1px solid rgba(214, 179, 112, 0.25);
+  border-radius: 18px;
+  padding: clamp(0.9rem, 2.4vw, 1.35rem);
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.screen--bestiary .codex-section__title {
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.screen--bestiary .codex-section__icons {
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.screen--bestiary .codex-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+}
+
+.screen--bestiary .codex-icon__image {
+  filter: drop-shadow(0 5px 10px rgba(0, 0, 0, 0.55));
+}
+
 .codex-overlay {
   position: fixed;
   inset: 0;
@@ -783,6 +884,10 @@ button {
   padding-bottom: clamp(2.5rem, 6vw, 3.25rem);
 }
 
+.screen--bestiary .codex-shell--paged {
+  padding-bottom: clamp(2rem, 4vw, 2.75rem);
+}
+
 .codex {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
@@ -800,6 +905,10 @@ button {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--color-muted);
+}
+
+.screen--bestiary .codex__page-title {
+  text-align: center;
 }
 
 .codex__page-title.is-hidden {
@@ -923,12 +1032,12 @@ button {
   height: auto;
   background: rgba(12, 6, 3, 0.6);
   border: 1px solid rgba(214, 179, 112, 0.35);
-  padding: 0.5rem;
+  padding: clamp(0.65rem, 1.5vw, 1rem);
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
 }
 
 .codex-detail__image {
-  width: clamp(92px, 20vw, 136px);
+  width: clamp(136px, 28vw, 240px);
   max-width: 100%;
   height: auto;
   display: block;


### PR DESCRIPTION
## Summary
- Center the main menu panel and adjust spacing so it fits comfortably without scrolling.
- Expand the bestiary view with a wider grid layout for section icons and aligned detail panel.
- Enlarge showcased artwork in codex details for enemies, bosses, and player ghosts.

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb3cdde5c4832c978df41a2fd7569a