### PR TITLE
Revamp codex overlays and corridor navigation

### DIFF
--- a/main.js
+++ b/main.js
@@ -92,6 +92,61 @@
     },
   ];
 
+  const BESTIARY_PAGES = [
+    {
+      key: "memoriesActions",
+      title: "Memories & Actions",
+      sections: [
+        {
+          type: "memory",
+          emptyText: "No memories recorded in this ledger.",
+        },
+        {
+          type: "action",
+          emptyText: "No actions documented yet.",
+        },
+      ],
+    },
+    {
+      key: "relicsConsumables",
+      title: "Relics & Consumables",
+      sections: [
+        {
+          type: "relic",
+          emptyText: "No relics recorded in this ledger.",
+        },
+        {
+          type: "consumable",
+          emptyText: "No consumables catalogued.",
+        },
+      ],
+    },
+    {
+      key: "enemiesBosses",
+      title: "Enemies & Bosses",
+      sections: [
+        {
+          type: "enemy",
+          emptyText: "No enemies have been catalogued.",
+        },
+        {
+          type: "boss",
+          emptyText: "No bosses have been recorded.",
+        },
+      ],
+    },
+    {
+      key: "playerGhosts",
+      title: "Player Ghosts",
+      sections: [
+        {
+          type: "playerGhost",
+          emptyText: "No player apparitions have manifested.",
+        },
+      ],
+    },
+  ];
+
   const DOOR_SPRITES = {
     base: "objspr_doors_door.png",
     lock: "objspr_doors_lock.png",
@@ -1879,6 +1934,7 @@
     selectedDrafts: [],
     resourceDisplays: {},
     codexView: null,
+    codexSelections: {},
     activeCombat: null,
     activeScreenContext: null,
     merchantDraftCost: MERCHANT_BASE_DRAFT_COST,
@@ -1975,6 +2031,7 @@
     state.draftPacks = [];
     state.selectedDrafts = [];
     state.codexView = null;
+    state.codexSelections = {};
     state.activeCombat = null;
     state.activeScreenContext = null;
     state.merchantDraftCost = MERCHANT_BASE_DRAFT_COST;
@@ -2004,6 +2061,7 @@
     state.draftPacks = [];
     state.selectedDrafts = [];
     state.codexView = null;
+    state.codexSelections = {};
     state.activeCombat = null;
     state.activeScreenContext = null;
     state.merchantDraftCost = MERCHANT_BASE_DRAFT_COST;
@@ -2177,7 +2235,7 @@
           "button menu__button",
           "Bestiary"
         );
-        bestiaryBtn.addEventListener("click", () => ctx.transitionTo("bestiary"));
+        bestiaryBtn.addEventListener("click", () => showBestiary(ctx));
 
         const settingsBtn = createElement(
           "button",
@@ -2188,115 +2246,12 @@
 
         const exitBtn = createElement("button", "button menu__button", "Exit");
         exitBtn.addEventListener("click", () => {
-          ctx.showToast("Exit will be available in the desktop build.");
+          ctx.exitGame();
         });
 
         menu.append(continueBtn, newRunBtn, bestiaryBtn, settingsBtn, exitBtn);
         panel.append(title, subtitle, menu);
         wrapper.append(panel);
-        return wrapper;
-      },
-    },
-    bestiary: {
-      key: "bestiary",
-      type: "menu",
-      ariaLabel: "Wallpaper from inside Cebarti Manor, used for menus.",
-      render(ctx) {
-        const wrapper = createElement("div", "screen screen--menu screen--bestiary");
-        const panel = createElement("div", "panel panel--codex");
-
-        const title = createElement("h2", "screen__title", "Bestiary");
-        const subtitle = createElement(
-          "p",
-          "screen__subtitle",
-          "Peruse the manor's memories, actions, relics, and denizens."
-        );
-
-        const content = createElement(
-          "div",
-          "codex-panel__content codex-panel__content--screen"
-        );
-        const viewState = { selectedKey: null, selectedType: null, pageIndex: 0 };
-        const bestiaryPages = [
-          {
-            key: "memoriesActions",
-            title: "Memories & Actions",
-            sections: [
-              {
-                type: "memory",
-                emptyText: "No memories recorded in this ledger.",
-              },
-              {
-                type: "action",
-                emptyText: "No actions documented yet.",
-              },
-            ],
-          },
-          {
-            key: "relicsConsumables",
-            title: "Relics & Consumables",
-            sections: [
-              {
-                type: "relic",
-                emptyText: "No relics recorded in this ledger.",
-              },
-              {
-                type: "consumable",
-                emptyText: "No consumables catalogued.",
-              },
-            ],
-          },
-          {
-            key: "enemiesBosses",
-            title: "Enemies & Bosses",
-            sections: [
-              {
-                type: "enemy",
-                emptyText: "No enemies have been catalogued.",
-              },
-              {
-                type: "boss",
-                emptyText: "No bosses have been recorded.",
-              },
-            ],
-          },
-          {
-            key: "playerGhosts",
-            title: "Player Ghosts",
-            sections: [
-              {
-                type: "playerGhost",
-                emptyText: "No player apparitions have manifested.",
-              },
-            ],
-          },
-        ];
-        renderCodexContent(content, {
-          layout: "screen",
-          viewState,
-          memoryKeys: MEMORY_DEFINITIONS.map((memory) => memory.key),
-          actionKeys: Object.keys(ACTION_DEFINITIONS || {}),
-          relicKeys: RELIC_DEFINITIONS.map((relic) => relic.key),
-          consumableKeys: CONSUMABLE_DEFINITIONS.map((item) => item.key),
-          enemyKeys: enemySprites.map((sprite) => sprite.key),
-          bossKeys: bossSprites.map((sprite) => sprite.key),
-          playerGhostKeys: [playerCharacter.key],
-          pages: bestiaryPages,
-          emptyMessage: "Entries will appear here as development continues.",
-        });
-
-        panel.append(title, subtitle, content);
-
-        const footer = createElement("div", "screen-footer");
-        const backButton = createElement(
-          "button",
-          "button",
-          "Back to Menu"
-        );
-        backButton.addEventListener("click", () => ctx.transitionTo("mainMenu"));
-        footer.appendChild(backButton);
-
-        wrapper.append(panel, footer);
         return wrapper;
       },
     },
@@ -2567,9 +2522,8 @@
           });
         }
 
-        let footer = null;
+        const footer = createElement("div", "screen-footer");
         if (roomsRemaining > 0) {
-          footer = createElement("div", "screen-footer");
           const continueButton = createElement(
             "button",
             "button button--primary",
@@ -2584,10 +2538,27 @@
           footer.appendChild(continueButton);
         }
 
-        wrapper.append(tracker, title, subtitle, doorMap);
-        if (footer) {
-          wrapper.appendChild(footer);
-        }
+        const returnButton = createElement(
+          "button",
+          "button",
+          "Return to Main Menu"
+        );
+        returnButton.addEventListener("click", async () => {
+          const confirmReturn = window.confirm(
+            "Abandon this run and return to the main menu?"
+          );
+          if (!confirmReturn) {
+            return;
+          }
+          clearRunState();
+          await ctx.transitionTo("mainMenu");
+          ctx.showToast(
+            "You withdraw from the corridor and return to the manor's entry hall."
+          );
+        });
+        footer.appendChild(returnButton);
+
+        wrapper.append(tracker, title, subtitle, doorMap, footer);
         return wrapper;
       },
     },
@@ -2847,9 +2818,14 @@
     const frame = createElement("span", "door-button__frame");
     button.appendChild(frame);
 
-    const sprite = createElement("span", "door-button__sprite");
+    const sprite = document.createElement("img");
+    sprite.className = "door-button__sprite";
+    sprite.src = DOOR_SPRITES.base;
+    sprite.alt = "";
+    sprite.loading = "lazy";
+    sprite.decoding = "async";
+    sprite.draggable = false;
     sprite.setAttribute("aria-hidden", "true");
-    sprite.style.backgroundImage = `url(${DOOR_SPRITES.base})`;
     frame.appendChild(sprite);
 
     const shine = createElement("span", "door-button__shine");
@@ -3105,15 +3081,24 @@
   }
 
   function closeCodexOverlay() {
-    if (!state.codexView || state.codexView.mode !== "ledger") {
+    if (!state.codexView) {
       return;
     }
-    const { overlay, handleKeydown } = state.codexView;
+    const { overlay, handleKeydown, mode } = state.codexView;
     if (overlay?.parentElement) {
       overlay.parentElement.removeChild(overlay);
     }
     if (handleKeydown) {
       document.removeEventListener("keydown", handleKeydown);
+    }
+    state.codexSelections = state.codexSelections || {};
+    const selection = {
+      key: state.codexView.selectedKey || null,
+      type: state.codexView.selectedType || null,
+      pageIndex: state.codexView.pageIndex || 0,
+    };
+    if (mode) {
+      state.codexSelections[mode] = selection;
     }
     state.codexView = null;
   }
@@ -3972,46 +3957,30 @@
 
   function refreshCodexOverlay(ctxOverride) {
     const view = state.codexView;
-    if (!view || view.mode !== "ledger") {
+    if (!view || typeof view.renderContent !== "function") {
       return;
     }
     const ctx = ctxOverride || view.ctx || { state };
-    const memoryKeys = Array.isArray(ctx.state?.playerMemories)
-      ? ctx.state.playerMemories
-      : state.playerMemories || [];
-    const relicKeys = Array.isArray(ctx.state?.playerRelics)
-      ? ctx.state.playerRelics
-      : state.playerRelics || [];
-
-    view.content.replaceChildren();
-    const codexContainer = createElement("div");
-    renderCodexContent(codexContainer, {
-      layout: "overlay",
-      viewState: view,
-      memoryKeys,
-      relicKeys,
-      emptyMessage: "No memories or relics have been recorded yet.",
-    });
-    view.content.appendChild(codexContainer);
-
-    const consumablesSection = createConsumablesSection(ctx);
-    if (consumablesSection) {
-      view.content.appendChild(consumablesSection);
+    view.ctx = ctx;
+    if (!view.content) {
+      return;
     }
+    view.content.replaceChildren();
+    view.renderContent(view.content, ctx, view);
   }
 
-  function showLedger(ctx) {
-    if (state.codexView && state.codexView.mode === "ledger") {
+  function openCodexOverlay(mode, titleText, ctx, renderContent) {
+    if (state.codexView && state.codexView.mode === mode) {
+      state.codexView.ctx = ctx || state.codexView.ctx;
       refreshCodexOverlay(ctx);
       return;
     }
 
-    const previousSelection = state.codexView
-      ? {
-          key: state.codexView.selectedKey || null,
-          type: state.codexView.selectedType || null,
-        }
-      : { key: null, type: null };
+    const storedSelection = state.codexSelections?.[mode] || {
+      key: null,
+      type: null,
+      pageIndex: 0,
+    };
 
     closeCodexOverlay();
 
@@ -4021,7 +3990,7 @@
     panel.setAttribute("aria-modal", "true");
 
     const header = createElement("div", "codex-panel__header");
-    const title = createElement("h2", "codex-panel__title", "Memory Ledger");
+    const title = createElement("h2", "codex-panel__title", titleText);
     const closeButton = createElement("button", "codex-panel__close", "Close");
     closeButton.type = "button";
     closeButton.addEventListener("click", () => closeCodexOverlay());
@@ -4047,18 +4016,78 @@
     document.body.appendChild(overlay);
 
     state.codexView = {
-      mode: "ledger",
+      mode,
       overlay,
       panel,
       content,
       ctx,
       handleKeydown,
-      selectedKey: previousSelection.key,
-      selectedType: previousSelection.type,
+      selectedKey: storedSelection.key,
+      selectedType: storedSelection.type,
+      pageIndex: storedSelection.pageIndex || 0,
+      renderContent,
     };
 
     refreshCodexOverlay(ctx);
     window.requestAnimationFrame(() => closeButton.focus());
+  }
+
+  function showLedger(ctx) {
+    openCodexOverlay("ledger", "Memory Ledger", ctx, (target, renderCtx, viewState) => {
+      const memoryKeys = Array.isArray(renderCtx.state?.playerMemories)
+        ? renderCtx.state.playerMemories
+        : state.playerMemories || [];
+      const relicKeys = Array.isArray(renderCtx.state?.playerRelics)
+        ? renderCtx.state.playerRelics
+        : state.playerRelics || [];
+
+      const codexContainer = createElement("div");
+      renderCodexContent(codexContainer, {
+        layout: "overlay",
+        viewState,
+        memoryKeys,
+        relicKeys,
+        emptyMessage: "No memories or relics have been recorded yet.",
+      });
+      target.appendChild(codexContainer);
+
+      const consumablesSection = createConsumablesSection(renderCtx);
+      if (consumablesSection) {
+        target.appendChild(consumablesSection);
+      }
+    });
+  }
+
+  function showBestiary(ctx) {
+    openCodexOverlay(
+      "bestiary",
+      "Manor Bestiary",
+      ctx,
+      (target, renderCtx, viewState) => {
+        const intro = createElement(
+          "p",
+          "codex-panel__intro",
+          "Review every discovered memory, relic, apparition, and foe recorded across all runs."
+        );
+        target.appendChild(intro);
+
+        const codexContainer = createElement("div");
+        renderCodexContent(codexContainer, {
+          layout: "overlay",
+          viewState,
+          memoryKeys: MEMORY_DEFINITIONS.map((memory) => memory.key),
+          actionKeys: Object.keys(ACTION_DEFINITIONS || {}),
+          relicKeys: RELIC_DEFINITIONS.map((relic) => relic.key),
+          consumableKeys: CONSUMABLE_DEFINITIONS.map((item) => item.key),
+          enemyKeys: enemySprites.map((sprite) => sprite.key),
+          bossKeys: bossSprites.map((sprite) => sprite.key),
+          playerGhostKeys: [playerCharacter.key],
+          pages: BESTIARY_PAGES,
+          emptyMessage: "Entries will appear here as development continues.",
+        });
+        target.appendChild(codexContainer);
+      }
+    );
   }
 
   function addGold(amount, ctx) {
@@ -7068,6 +7097,21 @@
     }, duration);
   }
 
+  function exitGame() {
+    closeCodexOverlay();
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.setTimeout(() => {
+      window.close();
+      try {
+        window.location.href = "about:blank";
+      } catch (error) {
+        // ignore navigation errors in non-browser environments
+      }
+    }, 50);
+  }
+
   function fadeToBlack() {
     return new Promise((resolve) => {
       if (!fadeOverlay) {
@@ -7148,6 +7192,7 @@
       showToast,
       options,
       updateResources: updateResourceDisplays,
+      exitGame,
     };
 
     state.activeScreenContext = context;

--- a/styles.css
+++ b/styles.css
@@ -363,17 +363,14 @@ button {
 }
 
 .door-map {
-  width: min(820px, 92vw);
+  width: min(860px, 94vw);
   margin-inline: auto;
   padding: clamp(1.75rem, 4vw, 2.75rem);
-  display: grid;
-  grid-template-columns: repeat(
-    auto-fit,
-    minmax(clamp(160px, 24vw, 220px), 1fr)
-  );
-  gap: clamp(1.5rem, 3vw, 2.5rem);
-  align-items: start;
-  justify-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: clamp(1.5rem, 3vw, 3rem);
   background: rgba(10, 5, 2, 0.6);
   border: 1px solid rgba(214, 179, 112, 0.35);
   border-radius: 26px;
@@ -400,22 +397,33 @@ button {
   width: 100%;
   height: 100%;
   border-radius: 20px;
-  overflow: hidden;
-  background: rgba(8, 4, 2, 0.65);
+  overflow: visible;
+  background: linear-gradient(
+    180deg,
+    rgba(8, 4, 2, 0.76),
+    rgba(8, 4, 2, 0.55) 60%,
+    rgba(6, 3, 1, 0.78)
+  );
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
   transition: box-shadow 180ms ease, transform 180ms ease;
   transform: translateY(var(--door-raise, 0px));
+  padding: clamp(0.85rem, 2.4vw, 1.15rem)
+    clamp(0.7rem, 2.2vw, 1.05rem)
+    clamp(1.1rem, 3vw, 1.6rem);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
 }
 
 .door-button__sprite {
-  position: absolute;
-  inset: 0;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-  background-image: url("objspr_doors_door.png");
+  position: relative;
+  width: 100%;
+  height: auto;
+  max-height: 100%;
   filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.65));
   transition: filter 180ms ease;
+  pointer-events: none;
+  user-select: none;
 }
 
 .door-button__shine {
@@ -429,27 +437,32 @@ button {
   opacity: 0;
   transition: opacity 200ms ease;
   pointer-events: none;
+  border-radius: 18px;
 }
 
 .door-button__icon {
   position: absolute;
-  top: 8%;
+  top: -18%;
   left: 50%;
   transform: translate(-50%, 0);
-  width: 58%;
+  width: 64%;
+  max-width: 132px;
   pointer-events: none;
   transition: filter 200ms ease, transform 200ms ease;
+  filter: drop-shadow(0 6px 14px rgba(0, 0, 0, 0.5));
+  z-index: 2;
 }
 
 .door-button__lock {
   position: absolute;
+  top: 50%;
   left: 50%;
-  bottom: 20%;
-  width: 32%;
-  transform: translate(-50%, 10%) scale(0.85);
+  width: 34%;
+  transform: translate(-50%, -36%) scale(0.85);
   opacity: 0;
   pointer-events: none;
   transition: opacity 220ms ease, transform 220ms ease;
+  z-index: 3;
 }
 
 .door-button:focus-visible {
@@ -865,6 +878,13 @@ button {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+}
+
+.codex-panel__intro {
+  margin: 0 0 clamp(1rem, 3vw, 1.5rem);
+  color: var(--color-muted);
+  line-height: 1.65;
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
 }
 
 .codex-panel__content--screen {
@@ -1421,40 +1441,13 @@ button {
   align-self: flex-start;
 }
 
-.door-button--amber {
-  background: radial-gradient(circle at 30% 30%, #fff8c2, #bfa12c 68%, #6a5207 100%);
-}
-
-.door-button--azure {
-  background: radial-gradient(circle at 30% 30%, #f0f7ff, #3b74b8 70%, #15385d 100%);
-}
-
-.door-button--crimson {
-  background: radial-gradient(circle at 30% 30%, #ffe6e0, #b43a32 68%, #5a0909 100%);
-}
-
-.door-button--verdant {
-  background: radial-gradient(circle at 30% 30%, #e9fbe8, #4f9c55 70%, #1f5027 100%);
-}
-
-.door-button--violet {
-  background: radial-gradient(circle at 30% 30%, #f3e8ff, #7b52b7 70%, #33124f 100%);
-}
-
-.door-button--umbra {
-  background: radial-gradient(circle at 30% 30%, #f5ecff, #59468d 64%, #120825 100%);
-}
-
-.door-button--aether {
-  background: radial-gradient(circle at 30% 30%, #e8fbff, #3c8f9b 68%, #0a343d 100%);
-}
-
 .door-option {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.75rem;
-  max-width: clamp(160px, 24vw, 220px);
+  flex: 0 1 clamp(180px, 22vw, 220px);
+  width: clamp(180px, 22vw, 220px);
   text-align: center;
 }
 
@@ -2000,13 +1993,13 @@ button {
 
 @media (max-width: 720px) {
   .door-map {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     padding: clamp(1.25rem, 5vw, 1.75rem);
     gap: clamp(1.25rem, 4vw, 2rem);
   }
 
   .door-option {
-    max-width: 220px;
+    flex: 1 1 clamp(160px, 48vw, 220px);
+    width: clamp(160px, 48vw, 220px);
   }
 
   .screen-footer .button {


### PR DESCRIPTION
## Summary
- add a shared codex overlay flow so the bestiary and ledger use the same UI, including full-game page data for the bestiary
- enable the main menu exit button and hook the bestiary button into the new overlay
- refresh corridor door presentation and add a return-to-menu option for abandoning a run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb5325ddb0832cb7b7ef7ebb6baa67