### PR TITLE
Add bestiary dev mode toggle UI

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -852,6 +852,12 @@ button {
   gap: 1rem;
 }
 
+.codex-panel__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .codex-panel__title {
   font-size: 1.45rem;
 }
@@ -871,6 +877,65 @@ button {
   background: rgba(214, 179, 112, 0.35);
   outline: none;
   transform: translateY(-1px);
+}
+
+.codex-dev-toggle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(214, 179, 112, 0.45);
+  background: rgba(214, 179, 112, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease, box-shadow 160ms ease,
+    border-color 160ms ease;
+}
+
+.codex-dev-toggle:hover,
+.codex-dev-toggle:focus-visible {
+  background: rgba(214, 179, 112, 0.25);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.codex-dev-toggle__logo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.4));
+}
+
+.codex-dev-toggle--active {
+  background: rgba(255, 214, 102, 0.25);
+  border-color: rgba(255, 214, 102, 0.8);
+  box-shadow: 0 0 0 2px rgba(255, 214, 102, 0.45),
+    0 10px 18px rgba(0, 0, 0, 0.35);
+}
+
+.codex-panel--dev-active .codex-dev-toggle {
+  border-color: rgba(255, 214, 102, 0.6);
+}
+
+.codex-overlay--dev-mode .codex-panel__title::after {
+  content: " • Dev Mode";
+  margin-left: 0.25rem;
+  font-size: 0.75rem;
+  color: rgba(255, 214, 102, 0.85);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.codex-dev-highlight {
+  transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.codex-overlay--dev-mode .codex-dev-highlight,
+.codex-panel--dev-active .codex-dev-highlight {
+  background: rgba(255, 214, 102, 0.1);
+  box-shadow: 0 0 0 1px rgba(255, 214, 102, 0.45);
 }
 
 .codex-panel__content {


### PR DESCRIPTION
## Summary
- add a persistent devMode flag to the shared state
- render an Anabolic Scrub Studios logo toggle in the bestiary header that flips dev mode
- style the new toggle and expose CSS hooks for future dev-only highlighting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb5e49b210832c9baf40f0e1131b9b