### PR TITLE
Enable editing of bestiary values in dev mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -938,6 +938,25 @@ button {
   box-shadow: 0 0 0 1px rgba(255, 214, 102, 0.45);
 }
 
+.codex-dev-input {
+  width: auto;
+  min-width: 3.5ch;
+  max-width: 9ch;
+  padding: 0.1rem 0.3rem;
+  margin: 0;
+  border: 1px solid rgba(255, 214, 102, 0.65);
+  border-radius: 4px;
+  background: rgba(17, 10, 6, 0.8);
+  color: inherit;
+  font: inherit;
+  text-align: center;
+}
+
+.codex-dev-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 214, 102, 0.55);
+}
+
 .dev-editable {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add helper bindings so codex entries can map displayed numbers back to their source definitions
- upgrade bestiary data builders to attach dev bindings for stats, descriptions, contributions, and move data
- render codex numeric values as editable inputs in dev mode and style the new inputs

## Testing
- node --check main.js

------
https://chatgpt.com/codex/tasks/task_e_68cb6372c1ac832c8d85644e1bfedf78