### PR TITLE
Share ensureDefaultMemories helper with combat engine

### DIFF
--- a/src/combat/engine.js
+++ b/src/combat/engine.js
@@ -19,6 +19,7 @@ import {
   setEssenceValues,
   updateState,
 } from '../state/state.js';
+import { ensureDefaultMemories } from '../state/memories.js';
 import {
   DEFAULT_PLAYER_STATS,
   MERCHANT_BASE_DRAFT_COST,

--- a/src/main.js
+++ b/src/main.js
@@ -2331,18 +2331,6 @@ import screenModules from "./ui/screens/index.js";
     return encounterType === "combat" || encounterType === "elite" || encounterType === "boss";
   }
 
-  function ensureDefaultMemories(ctx) {
-    if (!Array.isArray(ctx.state.playerMemories) || ctx.state.playerMemories.length === 0) {
-      updateState({
-        playerMemories: [
-          "memoryBarFight",
-          "memoryWatchman",
-          "memorySong",
-        ],
-      });
-    }
-  }
-
   function getBackgroundForScreen(screenDef, options = {}) {
     if (options.background) {
       return options.background;

--- a/src/state/memories.js
+++ b/src/state/memories.js
@@ -1,0 +1,25 @@
+import { updateState } from "./state.js";
+
+const DEFAULT_PLAYER_MEMORIES = [
+  "memoryBarFight",
+  "memoryWatchman",
+  "memorySong",
+];
+
+export function ensureDefaultMemories(ctx) {
+  const contextState = ctx && typeof ctx === "object" ? ctx.state : null;
+  const memories = contextState?.playerMemories;
+  if (Array.isArray(memories) && memories.length > 0) {
+    return memories;
+  }
+
+  const updatedState = updateState({
+    playerMemories: DEFAULT_PLAYER_MEMORIES.slice(),
+  });
+
+  if (contextState && contextState !== updatedState) {
+    contextState.playerMemories = updatedState.playerMemories.slice();
+  }
+
+  return updatedState.playerMemories;
+}


### PR DESCRIPTION
## Summary
- move ensureDefaultMemories into a reusable state/memories helper
- import the shared helper in the combat engine before building combat state
- remove the inline ensureDefaultMemories definition from the main entry point

## Testing
- python -m http.server 8000 & (manual browser test scripted via Playwright to start a combat encounter)


------
https://chatgpt.com/codex/tasks/task_e_68cc3fbb1d44832cb025ead3afec09ed