### PR TITLE
Ensure game shell exists before rendering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,7 @@ import {
   replaceContent,
   showToast,
   updateBackground,
+  ensureGameShell,
 } from "./ui/dom.js";
 import {
   applyRecoveryRoomBenefits,
@@ -582,6 +583,7 @@ import screenModules from "./ui/screens/index.js";
   }
 
   function startApplication() {
+    ensureGameShell();
     initialize();
   }
 


### PR DESCRIPTION
## Summary
- make the DOM helpers rebuild the game container elements if the expected markup is missing so the app can recover from an empty page
- call the new ensureGameShell helper before initialization so the splash screen is always rendered even if the host page omits the game skeleton

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc57fa71ac832c9b2bd54e17eb3401