### PR TITLE
Fix bestiary detail alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1023,6 +1023,7 @@ button {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--color-muted);
+  grid-column: 1 / -1;
 }
 
 .screen--bestiary .codex__page-title {


### PR DESCRIPTION
## Summary
- ensure the bestiary page header spans the full grid width so the detail panel sits beside the entry list

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc7ef683e4832cb4ca4daddf9c430d