### PR TITLE
Fix missing random helper import for combat rewards

### DIFF
--- a/src/combat/engine.js
+++ b/src/combat/engine.js
@@ -31,7 +31,7 @@ import {
   MERCHANT_BASE_DRAFT_COST,
   MERCHANT_DRAFT_COST_INCREMENT,
 } from '../state/config.js';
-import { sampleWithoutReplacement } from '../state/random.js';
+import { getRandomItem, sampleWithoutReplacement } from '../state/random.js';
 import { showFloatingText, updateCombatLog, updateCombatUI } from '../ui/combat.js';
 import { createElement } from '../ui/dom.js';
 

--- a/src/state/random.js
+++ b/src/state/random.js
@@ -14,3 +14,11 @@ export function sampleWithoutReplacement(source, count) {
   const pool = shuffle(source);
   return pool.slice(0, Math.min(count, pool.length));
 }
+
+export function getRandomItem(source) {
+  if (!Array.isArray(source) || source.length === 0) {
+    return null;
+  }
+  const index = Math.floor(Math.random() * source.length);
+  return source[index];
+}

--- a/src/state/run.js
+++ b/src/state/run.js
@@ -12,7 +12,7 @@ import {
   clearCodexView,
   updateState,
 } from "./state.js";
-import { sampleWithoutReplacement } from "./random.js";
+import { getRandomItem, sampleWithoutReplacement } from "./random.js";
 import {
   DEFAULT_PLAYER_STATS,
   MERCHANT_BASE_DRAFT_COST,
@@ -90,14 +90,6 @@ export function clearRunState(options = {}) {
   });
   clearCodexView();
   clearActiveCombat();
-}
-
-function getRandomItem(source) {
-  if (!Array.isArray(source) || source.length === 0) {
-    return null;
-  }
-  const index = Math.floor(Math.random() * source.length);
-  return source[index];
 }
 
 function getEncounterPoolForType(type) {


### PR DESCRIPTION
## Summary
- export a reusable `getRandomItem` helper from the random utilities module
- reuse the helper in run state management and the combat engine so consumable drops work without throwing

## Testing
- node --no-warnings --input-type=module -e "import('./src/state/random.js').then(m => console.log('random item test', typeof m.getRandomItem([1,2,3])))"


------
https://chatgpt.com/codex/tasks/task_e_68cda4250ba8832cbbf68de168eedbcc