### PR TITLE
Implement dev tools, merchant specializations, and new relic passives

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -41,6 +41,13 @@ export const RELIC_DEFINITIONS = [
     passive: { throwAppliesVulnerable: 1 },
   },
   {
+    key: "relicSequencersDial",
+    name: "Sequencer's Dial",
+    emotion: "Anger",
+    description: "Your action bar holds an additional slot.",
+    passive: { actionSlotBonus: 1 },
+  },
+  {
     key: "relicPorcelainRat",
     name: "Porcelain Rat Figurine",
     emotion: "Fear",
@@ -78,6 +85,13 @@ export const RELIC_DEFINITIONS = [
     passive: { armorGainNoAttack: 2 },
   },
   {
+    key: "relicWardweaversSpindle",
+    name: "Wardweaver's Spindle",
+    emotion: "Fear",
+    description: "Whenever an action cycles in its chain, gain Block (4).",
+    passive: { cycleBlockGain: 4 },
+  },
+  {
     key: "relicLanternFestival",
     name: "Lantern of Festival Glass",
     emotion: "Joy",
@@ -90,6 +104,13 @@ export const RELIC_DEFINITIONS = [
     emotion: "Joy",
     description: "Spark deals +3 damage if you played a buff this turn.",
     passive: { sparkBuffBonus: 3 },
+  },
+  {
+    key: "relicCarnivalCartridge",
+    name: "Carnival Cartridge",
+    emotion: "Joy",
+    description: "Carry two additional consumables in your satchel.",
+    passive: { consumableSlotBonus: 2 },
   },
   {
     key: "relicGoldenLyre",
@@ -111,6 +132,13 @@ export const RELIC_DEFINITIONS = [
     emotion: "Joy",
     description: "The first buff you play each combat is duplicated.",
     passive: { firstBuffDuplicated: true },
+  },
+  {
+    key: "relicCuratorsCompass",
+    name: "Curator's Compass",
+    emotion: "Joy",
+    description: "Drafts present one additional option to choose from.",
+    passive: { draftOptionBonus: 1 },
   },
   {
     key: "relicDirgeBell",
@@ -146,6 +174,20 @@ export const RELIC_DEFINITIONS = [
     emotion: "Sadness",
     description: "If you played Breakthrough this combat, gain +15 gold at victory.",
     passive: { breakthroughGoldReward: 15 },
+  },
+  {
+    key: "relicGildedReliquary",
+    name: "Gilded Reliquary",
+    emotion: "Sadness",
+    description: "Whenever you claim a new memory, gain 10 gold.",
+    passive: { memoryPickupGold: 10 },
+  },
+  {
+    key: "relicBrokerSigil",
+    name: "Broker's Sigil",
+    emotion: "Sadness",
+    description: "Merchant activations cost half as much (rounded to the nearest gold).",
+    passive: { merchantCostMultiplier: 0.5 },
   },
 ];
 

--- a/src/main.js
+++ b/src/main.js
@@ -158,7 +158,7 @@ import { initializeDebugLogUI } from "./ui/debug-log.js";
   }
 
   function createDoorChoice(label, extraClasses = [], options = {}) {
-    const { button, iconElement, lockElement } = createDoorButton(
+    const { button, iconElement, lockElement, frame } = createDoorButton(
       label,
       extraClasses,
       options
@@ -178,7 +178,14 @@ import { initializeDebugLogUI } from "./ui/debug-log.js";
       wrapper.appendChild(detailElement);
     }
 
-    return { element: wrapper, button, labelElement, iconElement, lockElement };
+    return {
+      element: wrapper,
+      button,
+      labelElement,
+      iconElement,
+      lockElement,
+      frame,
+    };
   }
 
   const screenHelpers = {

--- a/src/state/inventory.js
+++ b/src/state/inventory.js
@@ -7,6 +7,10 @@ import {
   recordMemory,
 } from "./state.js";
 import { MAX_CONSUMABLE_SLOTS } from "./config.js";
+import {
+  getConsumableSlotLimit,
+  getPlayerPassiveSummary,
+} from "./passives.js";
 import { CONSUMABLE_MAP, MEMORY_MAP, RELIC_MAP } from "../data/index.js";
 import { isDevEntryDisabled } from "./devtools.js";
 
@@ -92,7 +96,8 @@ export function addConsumable(key, count = 1, ctx) {
   const currentTotal = getTotalConsumables();
   let success = false;
   if (count > 0) {
-    const remainingSlots = MAX_CONSUMABLE_SLOTS - currentTotal;
+    const capacity = getConsumableSlotLimit(context.state, MAX_CONSUMABLE_SLOTS);
+    const remainingSlots = capacity - currentTotal;
     if (remainingSlots <= 0) {
       context.showToast?.("Your satchel is full.");
       return false;
@@ -156,5 +161,10 @@ export function addMemoryToState(key, ctx) {
     context.showToast(`A new memory surfaces: ${memory?.name || key}.`);
   }
   notifyResourceUpdate(context);
+  const passiveSummary = getPlayerPassiveSummary();
+  const memoryGold = Math.max(0, Math.round(passiveSummary.memoryPickupGold || 0));
+  if (memoryGold > 0) {
+    addGold(memoryGold, context);
+  }
   return true;
 }

--- a/src/state/passives.js
+++ b/src/state/passives.js
@@ -1,0 +1,272 @@
+import { MEMORY_MAP, RELIC_MAP } from "../data/index.js";
+import { isDevEntryDisabled } from "./devtools.js";
+import { getState } from "./state.js";
+
+export function createPassiveSummary() {
+  return {
+    bleedBonus: 0,
+    bleedMultiplier: 1,
+    bleedHealFraction: 0,
+    apCarryoverBonus: 0,
+    dirgeCostReduction: 0,
+    roarAppliesVulnerable: false,
+    buffCostReductionWhileFaceUp: false,
+    songEssenceRegen: 0,
+    laughterDamageBonus: 0,
+    emptySlotCritBonus: 0,
+    buffGrantsEssenceRegen: 0,
+    strikeDamageBonus: 0,
+    grappleDiscountAfterStrike: 0,
+    grappleRestrainedBonus: 0,
+    strikeFaceUpCritBonus: 0,
+    throwAppliesVulnerable: 0,
+    blockThresholdDaze: 0,
+    blockThresholdDazeStacks: 0,
+    guardBlockBonus: 0,
+    braceRetaliate: 0,
+    counterBlockedBonusDamage: 0,
+    armorGainNoAttack: 0,
+    sparkBuffBonus: 0,
+    festivalLightCritBonus: 0,
+    elationEndHeal: 0,
+    firstBuffDuplicated: false,
+    witherAppliesExtraBleed: 0,
+    breakthroughFatigueDiscount: 0,
+    fatigueApBonus: 0,
+    burdenFaceUpArmor: 0,
+    breakthroughGoldReward: 0,
+    actionSlotBonus: 0,
+    consumableSlotBonus: 0,
+    memoryPickupGold: 0,
+    draftOptionBonus: 0,
+    cycleBlockGain: 0,
+    merchantCostMultiplier: 1,
+  };
+}
+
+export function summarizeMemoryPassives(memoryKeys = []) {
+  const summary = createPassiveSummary();
+  memoryKeys.forEach((key) => {
+    if (isDevEntryDisabled("memory", key)) {
+      return;
+    }
+    const memory = MEMORY_MAP.get(key);
+    if (!memory || !memory.passive) {
+      return;
+    }
+    const passive = memory.passive;
+    if (typeof passive.bleedBonus === "number") {
+      summary.bleedBonus += passive.bleedBonus;
+    }
+    if (typeof passive.apCarryoverBonus === "number") {
+      summary.apCarryoverBonus += passive.apCarryoverBonus;
+    }
+    if (typeof passive.dirgeCostReduction === "number") {
+      summary.dirgeCostReduction += passive.dirgeCostReduction;
+    }
+    if (passive.roarAppliesVulnerable) {
+      summary.roarAppliesVulnerable = true;
+    }
+    if (passive.buffCostReductionWhileFaceUp) {
+      summary.buffCostReductionWhileFaceUp = true;
+    }
+    if (typeof passive.songEssenceRegen === "number") {
+      summary.songEssenceRegen += passive.songEssenceRegen;
+    }
+    if (typeof passive.laughterDamageBonus === "number") {
+      summary.laughterDamageBonus += passive.laughterDamageBonus;
+    }
+    if (typeof passive.emptySlotCritBonus === "number") {
+      summary.emptySlotCritBonus += passive.emptySlotCritBonus;
+    }
+  });
+  return summary;
+}
+
+export function summarizeRelicPassives(relicKeys = []) {
+  const summary = createPassiveSummary();
+  relicKeys.forEach((key) => {
+    if (isDevEntryDisabled("relic", key)) {
+      return;
+    }
+    const relic = RELIC_MAP.get(key);
+    if (!relic || !relic.passive) {
+      return;
+    }
+    const passive = relic.passive;
+    if (typeof passive.bleedBonus === "number") {
+      summary.bleedBonus += passive.bleedBonus;
+    }
+    if (typeof passive.buffGrantsEssenceRegen === "number") {
+      summary.buffGrantsEssenceRegen += passive.buffGrantsEssenceRegen;
+    }
+    if (typeof passive.bleedMultiplier === "number") {
+      summary.bleedMultiplier *= passive.bleedMultiplier;
+    }
+    if (typeof passive.bleedHealFraction === "number") {
+      summary.bleedHealFraction += passive.bleedHealFraction;
+    }
+    if (typeof passive.strikeDamageBonus === "number") {
+      summary.strikeDamageBonus += passive.strikeDamageBonus;
+    }
+    if (typeof passive.grappleDiscountAfterStrike === "number") {
+      summary.grappleDiscountAfterStrike += passive.grappleDiscountAfterStrike;
+    }
+    if (typeof passive.grappleRestrainedBonus === "number") {
+      summary.grappleRestrainedBonus += passive.grappleRestrainedBonus;
+    }
+    if (typeof passive.strikeFaceUpCritBonus === "number") {
+      summary.strikeFaceUpCritBonus += passive.strikeFaceUpCritBonus;
+    }
+    if (typeof passive.throwAppliesVulnerable === "number") {
+      summary.throwAppliesVulnerable += passive.throwAppliesVulnerable;
+    }
+    if (typeof passive.blockThresholdDaze === "number" && passive.blockThresholdDaze > 0) {
+      summary.blockThresholdDaze =
+        summary.blockThresholdDaze > 0
+          ? Math.min(summary.blockThresholdDaze, passive.blockThresholdDaze)
+          : passive.blockThresholdDaze;
+    }
+    if (typeof passive.blockThresholdDazeStacks === "number") {
+      summary.blockThresholdDazeStacks += passive.blockThresholdDazeStacks;
+    }
+    if (typeof passive.guardBlockBonus === "number") {
+      summary.guardBlockBonus += passive.guardBlockBonus;
+    }
+    if (typeof passive.braceRetaliate === "number") {
+      summary.braceRetaliate += passive.braceRetaliate;
+    }
+    if (typeof passive.counterBlockedBonusDamage === "number") {
+      summary.counterBlockedBonusDamage += passive.counterBlockedBonusDamage;
+    }
+    if (typeof passive.armorGainNoAttack === "number") {
+      summary.armorGainNoAttack += passive.armorGainNoAttack;
+    }
+    if (typeof passive.sparkBuffBonus === "number") {
+      summary.sparkBuffBonus += passive.sparkBuffBonus;
+    }
+    if (typeof passive.festivalLightCritBonus === "number") {
+      summary.festivalLightCritBonus += passive.festivalLightCritBonus;
+    }
+    if (typeof passive.elationEndHeal === "number") {
+      summary.elationEndHeal += passive.elationEndHeal;
+    }
+    if (passive.firstBuffDuplicated) {
+      summary.firstBuffDuplicated = true;
+    }
+    if (typeof passive.witherAppliesExtraBleed === "number") {
+      summary.witherAppliesExtraBleed += passive.witherAppliesExtraBleed;
+    }
+    if (typeof passive.breakthroughFatigueDiscount === "number") {
+      summary.breakthroughFatigueDiscount += passive.breakthroughFatigueDiscount;
+    }
+    if (typeof passive.fatigueApBonus === "number") {
+      summary.fatigueApBonus += passive.fatigueApBonus;
+    }
+    if (typeof passive.burdenFaceUpArmor === "number") {
+      summary.burdenFaceUpArmor += passive.burdenFaceUpArmor;
+    }
+    if (typeof passive.breakthroughGoldReward === "number") {
+      summary.breakthroughGoldReward += passive.breakthroughGoldReward;
+    }
+    if (typeof passive.actionSlotBonus === "number") {
+      summary.actionSlotBonus += passive.actionSlotBonus;
+    }
+    if (typeof passive.consumableSlotBonus === "number") {
+      summary.consumableSlotBonus += passive.consumableSlotBonus;
+    }
+    if (typeof passive.memoryPickupGold === "number") {
+      summary.memoryPickupGold += passive.memoryPickupGold;
+    }
+    if (typeof passive.draftOptionBonus === "number") {
+      summary.draftOptionBonus += passive.draftOptionBonus;
+    }
+    if (typeof passive.cycleBlockGain === "number") {
+      summary.cycleBlockGain += passive.cycleBlockGain;
+    }
+    if (typeof passive.merchantCostMultiplier === "number") {
+      summary.merchantCostMultiplier *= passive.merchantCostMultiplier;
+    }
+  });
+  return summary;
+}
+
+export function combinePassiveSummaries(memorySummary, relicSummary) {
+  const combined = createPassiveSummary();
+  const numericKeys = [
+    "bleedBonus",
+    "apCarryoverBonus",
+    "dirgeCostReduction",
+    "songEssenceRegen",
+    "laughterDamageBonus",
+    "emptySlotCritBonus",
+    "buffGrantsEssenceRegen",
+    "strikeDamageBonus",
+    "grappleDiscountAfterStrike",
+    "grappleRestrainedBonus",
+    "strikeFaceUpCritBonus",
+    "throwAppliesVulnerable",
+    "blockThresholdDazeStacks",
+    "guardBlockBonus",
+    "braceRetaliate",
+    "counterBlockedBonusDamage",
+    "armorGainNoAttack",
+    "sparkBuffBonus",
+    "festivalLightCritBonus",
+    "elationEndHeal",
+    "witherAppliesExtraBleed",
+    "breakthroughFatigueDiscount",
+    "fatigueApBonus",
+    "burdenFaceUpArmor",
+    "breakthroughGoldReward",
+    "actionSlotBonus",
+    "consumableSlotBonus",
+    "memoryPickupGold",
+    "draftOptionBonus",
+    "cycleBlockGain",
+  ];
+  numericKeys.forEach((key) => {
+    combined[key] =
+      (combined[key] || 0) + (memorySummary[key] || 0) + (relicSummary[key] || 0);
+  });
+  combined.bleedMultiplier =
+    (memorySummary.bleedMultiplier || 1) * (relicSummary.bleedMultiplier || 1);
+  combined.bleedHealFraction =
+    (memorySummary.bleedHealFraction || 0) + (relicSummary.bleedHealFraction || 0);
+  combined.roarAppliesVulnerable = Boolean(
+    memorySummary.roarAppliesVulnerable || relicSummary.roarAppliesVulnerable
+  );
+  combined.buffCostReductionWhileFaceUp = Boolean(
+    memorySummary.buffCostReductionWhileFaceUp ||
+      relicSummary.buffCostReductionWhileFaceUp
+  );
+  combined.firstBuffDuplicated = Boolean(
+    memorySummary.firstBuffDuplicated || relicSummary.firstBuffDuplicated
+  );
+  const blockThresholds = [
+    memorySummary.blockThresholdDaze,
+    relicSummary.blockThresholdDaze,
+  ].filter((value) => typeof value === "number" && value > 0);
+  combined.blockThresholdDaze = blockThresholds.length
+    ? Math.min(...blockThresholds)
+    : 0;
+  combined.merchantCostMultiplier =
+    (memorySummary.merchantCostMultiplier || 1) *
+    (relicSummary.merchantCostMultiplier || 1);
+  return combined;
+}
+
+export function getPlayerPassiveSummary(stateOverride = null) {
+  const state = stateOverride || getState();
+  const memoryKeys = Array.isArray(state.playerMemories) ? state.playerMemories : [];
+  const relicKeys = Array.isArray(state.playerRelics) ? state.playerRelics : [];
+  const memorySummary = summarizeMemoryPassives(memoryKeys);
+  const relicSummary = summarizeRelicPassives(relicKeys);
+  return combinePassiveSummaries(memorySummary, relicSummary);
+}
+
+export function getConsumableSlotLimit(stateOverride = null, baseSlots = 3) {
+  const summary = getPlayerPassiveSummary(stateOverride);
+  const bonus = Math.max(0, Math.round(summary.consumableSlotBonus || 0));
+  return Math.max(baseSlots, baseSlots + bonus);
+}

--- a/src/ui/screens/corridor.js
+++ b/src/ui/screens/corridor.js
@@ -142,6 +142,7 @@ const corridorScreen = {
           iconElement,
           labelElement,
           lockElement,
+          frame,
         } = choice;
 
         if (iconElement) {
@@ -166,6 +167,38 @@ const corridorScreen = {
         doorButton.dataset.enhanced = enhanced ? "true" : "false";
         if (category.key) {
           doorButton.dataset.roomType = category.key;
+        }
+
+        if (ctx.state?.devMode && isLocked && frame) {
+          const devButton = createElement(
+            "button",
+            "door-button__dev-toggle",
+            ""
+          );
+          devButton.type = "button";
+          devButton.setAttribute("aria-label", "Unlock door in developer mode");
+          devButton.title = "Developer override: unlock without a key.";
+          const logo = document.createElement("img");
+          logo.src = "logofull.png";
+          logo.alt = "";
+          logo.loading = "lazy";
+          logo.decoding = "async";
+          logo.className = "door-button__dev-icon";
+          devButton.appendChild(logo);
+          devButton.addEventListener("click", (event) => {
+            event.stopPropagation();
+            event.preventDefault();
+            if (!isLocked) {
+              return;
+            }
+            isLocked = false;
+            doorButton.dataset.locked = "false";
+            doorButton.classList.remove("door-button--locked");
+            devButton.disabled = true;
+            devButton.classList.add("door-button__dev-toggle--used");
+            ctx.showToast?.("Developer override unlocks the door.");
+          });
+          frame.appendChild(devButton);
         }
 
         doorButton.addEventListener("click", async () => {

--- a/styles.css
+++ b/styles.css
@@ -465,6 +465,47 @@ button {
   z-index: 3;
 }
 
+.door-button__dev-toggle {
+  position: absolute;
+  bottom: -0.6rem;
+  right: -0.6rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  border: 1px solid rgba(214, 179, 112, 0.55);
+  background: rgba(12, 6, 3, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease, opacity 160ms ease;
+  z-index: 4;
+}
+
+.door-button__dev-icon {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.45));
+  pointer-events: none;
+}
+
+.door-button__dev-toggle:hover,
+.door-button__dev-toggle:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(255, 233, 189, 0.85);
+  box-shadow: 0 12px 18px rgba(0, 0, 0, 0.35);
+  outline: none;
+}
+
+.door-button__dev-toggle--used {
+  opacity: 0.35;
+  cursor: default;
+  box-shadow: none;
+  transform: none !important;
+}
+
 .door-button:focus-visible {
   outline: 3px solid rgba(255, 233, 189, 0.9);
   outline-offset: 6px;
@@ -747,6 +788,51 @@ button {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.merchant-panel__status {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 233, 189, 0.6);
+}
+
+.merchant-panel__message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 233, 189, 0.85);
+}
+
+.merchant-panel__empty {
+  margin: 0;
+  font-style: italic;
+  color: var(--color-muted);
+}
+
+.merchant-removal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.merchant-removal__option {
+  background: rgba(12, 6, 3, 0.6);
+  border: 1px solid rgba(214, 179, 112, 0.35);
+  border-radius: 12px;
+  color: inherit;
+  padding: 0.6rem 0.8rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
+}
+
+.merchant-removal__option:hover,
+.merchant-removal__option:focus-visible {
+  border-color: rgba(255, 233, 189, 0.85);
+  background: rgba(20, 11, 6, 0.78);
+  transform: translateY(-1px);
+  outline: none;
 }
 
 
@@ -1080,9 +1166,43 @@ button {
   gap: clamp(1rem, 2.5vw, 1.5rem);
 }
 
+.codex-section__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .codex-section__title {
+  margin: 0;
   font-size: 1rem;
   letter-spacing: 0.08em;
+}
+
+.codex-dev-group-toggle {
+  margin-left: auto;
+  border-radius: 999px;
+  border: 1px solid rgba(214, 179, 112, 0.45);
+  background: rgba(12, 6, 3, 0.7);
+  color: inherit;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.codex-dev-group-toggle[aria-pressed="true"] {
+  border-color: rgba(255, 206, 120, 0.85);
+  box-shadow: 0 0 0 2px rgba(255, 206, 120, 0.25);
+}
+
+.codex-dev-group-toggle:hover,
+.codex-dev-group-toggle:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(255, 233, 189, 0.85);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.35);
+  outline: none;
 }
 
 .codex-section__icons {
@@ -1854,6 +1974,75 @@ button {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.combat-sidebar__summary-text {
+  margin: 0;
+}
+
+.combat-dev-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(214, 179, 112, 0.45);
+  background: rgba(12, 6, 3, 0.7);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  padding: 0.35rem;
+}
+
+.combat-dev-button__icon {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.45));
+  pointer-events: none;
+}
+
+.combat-dev-button:hover,
+.combat-dev-button:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(255, 233, 189, 0.85);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.35);
+  outline: none;
+}
+
+.combat-dev-button--burn.is-active {
+  border-color: rgba(255, 206, 120, 0.9);
+  box-shadow: 0 0 0 2px rgba(255, 206, 120, 0.35);
+}
+
+.combat-action-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.combat-action-bar--burn-mode {
+  border: 1px dashed rgba(255, 206, 120, 0.5);
+  border-radius: 14px;
+  padding: 0.4rem;
+}
+
+.action-bar--burn-mode .action-button {
+  border-color: rgba(255, 206, 120, 0.35);
+}
+
+.action-button--dev-burn {
+  border-color: rgba(255, 206, 120, 0.8);
+  box-shadow: 0 0 0 3px rgba(255, 206, 120, 0.25);
+}
+
+.action-button--dev-burn:hover,
+.action-button--dev-burn:focus-visible {
+  border-color: rgba(255, 233, 189, 0.95);
 }
 
 .action-bar {


### PR DESCRIPTION
## Summary
- add a unified passive summary module and wire new relic effects into combat, inventory, and drafting systems
- specialize merchants with shared activation costs, per-visit limits, and removal services while supporting Helen’s mixed draft offerings
- expand developer tooling with bestiary toggle-all controls plus corridor and combat override buttons, including styling updates and new relic data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceb19805f4832c956e7e29adc9379b