### PR TITLE
Add background-themed manor events and codex support

### DIFF
--- a/src/data/bestiary.js
+++ b/src/data/bestiary.js
@@ -51,4 +51,14 @@ export const BESTIARY_PAGES = [
       },
     ],
   },
+  {
+    key: "events",
+    title: "Manor Events",
+    sections: [
+      {
+        type: "event",
+        emptyText: "No manor events have been chronicled.",
+      },
+    ],
+  },
 ];

--- a/src/data/events.js
+++ b/src/data/events.js
@@ -1,0 +1,201 @@
+export const EVENT_DEFINITIONS = [
+  {
+    key: "eventManorsFavor",
+    name: "Manor's Favor",
+    category: "boon",
+    summary: "Receive a random relic you do not already possess.",
+    effect: { type: "awardRandomRelic", count: 1 },
+    detailParagraphs: [
+      "The manor occasionally extends a gesture of goodwill, presenting a relic drawn from its vaults to bolster the next traveler.",
+    ],
+    ui: {
+      actionLabel: "Accept the Manor's Gift",
+      noEligibleText: "The manor has no further relics to bestow.",
+    },
+  },
+  {
+    key: "eventManorsTithe",
+    name: "Manor's Tithe",
+    category: "burden",
+    summary: "Surrender one relic or memory of your choice to appease the manor.",
+    effect: { type: "sacrificeRelicOrMemory", count: 1 },
+    detailParagraphs: [
+      "When the manor hungers, it demands that a cherished possession or memory be relinquished before it grants passage.",
+    ],
+    ui: {
+      confirmLabel: "Offer This Tribute",
+      choosePrompt: "Select a relic or memory to surrender.",
+      nothingToLoseText: "The manor finds nothing worth claiming and reluctantly lets you pass.",
+    },
+  },
+];
+
+export const EVENT_MAP = EVENT_DEFINITIONS.reduce((map, event) => {
+  map.set(event.key, event);
+  return map;
+}, new Map());
+
+export const ROOM_EVENT_FLAVORS = {
+  atrium: {
+    eventManorsFavor: {
+      description:
+        "Moonlight refracts through the flooded atrium, condensing around a drifting relic that waits to be claimed.",
+      resolution:
+        "The ripples settle as the gift settles into your grasp, the pool glowing with brief approval.",
+      failure:
+        "The reflecting pool dims; the atrium has no more treasures to reflect back at you.",
+    },
+    eventManorsTithe: {
+      description:
+        "Waterlogged ivy curls toward you, whispering that something dear must sink beneath the surface before you may leave.",
+      resolution:
+        "Your offering vanishes beneath the water, and the vines slacken their hold.",
+      failure:
+        "The ivy withers when it finds nothing of worth to drown.",
+    },
+  },
+  bedroom: {
+    eventManorsFavor: {
+      description:
+        "A lullaby hums from the wardrobe, coaxing a relic wrapped in velvet to float gently into the air before you.",
+      resolution:
+        "The lullaby fades to a contented sigh as the relic finds a new dream to haunt.",
+      failure:
+        "The melody unravels, revealing the wardrobe barren of further keepsakes.",
+    },
+    eventManorsTithe: {
+      description:
+        "Suspended furniture leans toward you, creaking for a memento to cradle in its restless embrace.",
+      resolution:
+        "Once appeased, the pieces drift back to their uneasy slumber.",
+      failure:
+        "Deprived of offerings, the bedroom furniture twists in frustrated circles before falling still.",
+    },
+  },
+  closet: {
+    eventManorsFavor: {
+      description:
+        "Key hooks clatter until one key-shaped relic glows white-hot, eager to fit a new lock in your possession.",
+      resolution:
+        "The keys quiet as the chosen relic slips into your satchel with a satisfied chime.",
+      failure:
+        "The jangling subsides, leaving only empty hooks and stale dust.",
+    },
+    eventManorsTithe: {
+      description:
+        "A rusted padlock snaps open and shut, demanding a treasured relic or memory to secure once more.",
+      resolution:
+        "Metal teeth bite down on your sacrifice, sealing the closet in smug silence.",
+      failure:
+        "Finding nothing to clamp down on, the locks rattle in annoyed futility.",
+    },
+  },
+  counsel: {
+    eventManorsFavor: {
+      description:
+        "Cushions depress as if unseen clients sit beside you, sliding a polished relic across the table as payment for your patience.",
+      resolution:
+        "The phantom session ends with a gentle nod, the relic warm from spectral hands.",
+      failure:
+        "The room remains tight-lipped; there are no more secrets to share tonight.",
+    },
+    eventManorsTithe: {
+      description:
+        "Ashes stir within the hearth, bartering for a confession in the form of something you value.",
+      resolution:
+        "Your concession feeds the coals, coaxing embers into a brief, approving flare.",
+      failure:
+        "Denied any offering, the hearth sulks cold and ashen.",
+    },
+  },
+  kitchen: {
+    eventManorsFavor: {
+      description:
+        "Copper lids lift on their own, unveiling a relic plated on fine porcelain amid impossible aromas.",
+      resolution:
+        "Utensils twirl with delight as you pocket the delicacy.",
+      failure:
+        "The ovens wheeze disappointment, empty of further delights.",
+    },
+    eventManorsTithe: {
+      description:
+        "The stove roars and hungry knives spin, insisting that you feed the kitchen something cherished.",
+      resolution:
+        "Flames purr contentedly as your offering sizzles into spectral steam.",
+      failure:
+        "Starved of tribute, the burners gutter into sullen embers.",
+    },
+  },
+  studio: {
+    eventManorsFavor: {
+      description:
+        "Paint seeps from canvases, sketching a relic's silhouette before solidifying into the real thing at your feet.",
+      resolution:
+        "Brushes clap together in applause as the artwork becomes your armament.",
+      failure:
+        "The colors run dry, their inspirations spent for now.",
+    },
+    eventManorsTithe: {
+      description:
+        "A blank canvas stretches taut, demanding pigment mixed from a memory or relic you hold dear.",
+      resolution:
+        "Once fed, the canvas drinks in your sacrifice and seals with a haunting new scene.",
+      failure:
+        "Unsated, the canvas sags and its frame creaks in disappointment.",
+    },
+  },
+  study: {
+    eventManorsFavor: {
+      description:
+        "Books flutter open, presenting a catalogued relic annotated with notes on how to wield it best.",
+      resolution:
+        "Satisfied pages slam shut after you claim the annotated prize.",
+      failure:
+        "The shelves rustle irritably; the ledger lists no further boons.",
+    },
+    eventManorsTithe: {
+      description:
+        "Glyphs blaze across the desk, calculating a tithe owed in memories or relics before releasing you.",
+      resolution:
+        "Equations resolve the moment your sacrifice touches the desk, ink cooling to calm lines.",
+      failure:
+        "Without payment, the formulas dissolve into static snow.",
+    },
+  },
+  washroom: {
+    eventManorsFavor: {
+      description:
+        "Mist draws symbols on the mirror before condensing into a gleaming relic resting on the porcelain sink.",
+      resolution:
+        "The mirrors clear once the gift is accepted, leaving only your determined reflection.",
+      failure:
+        "Condensation fades, revealing nothing but streaked glass and regret.",
+    },
+    eventManorsTithe: {
+      description:
+        "Shapes beyond the mirror tap insistently, demanding you trade a memory or relic to keep them at bay.",
+      resolution:
+        "Your offering smears across the glass, trapping the silhouettes for another night.",
+      failure:
+        "Without tribute, the tapping turns to annoyed scratches before it finally subsides.",
+    },
+  },
+  winecellar: {
+    eventManorsFavor: {
+      description:
+        "A cork pops itself free, pouring spectral wine that coalesces into a relic infused with aged celebration.",
+      resolution:
+        "The barrels hum in approval as you take the vintage blessing.",
+      failure:
+        "The casks groan empty—no more spirits wish to toast you.",
+    },
+    eventManorsTithe: {
+      description:
+        "Bottles clink in unison, thirsty for a keepsake to seal inside their dark glass.",
+      resolution:
+        "Once offered, the cellar buries your sacrifice in a hush of cork and shadow.",
+      failure:
+        "Denied sustenance, the bottles rattle in restless dismay.",
+    },
+  },
+};

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -5,3 +5,4 @@ export * from "./items.js";
 export * from "./memories.js";
 export * from "./enemies.js";
 export * from "./rooms.js";
+export * from "./events.js";

--- a/src/main.js
+++ b/src/main.js
@@ -453,6 +453,14 @@ import { initializeDebugLogUI } from "./ui/debug-log.js";
           : "A spectral merchant beckons you toward a clandestine bargain.";
       case "recovery":
         return "A stillness settles here, inviting your essence to linger and mend.";
+      case "event":
+        if (encounter?.flavor?.description) {
+          return encounter.flavor.description;
+        }
+        if (encounter?.definition?.summary) {
+          return encounter.definition.summary;
+        }
+        return "The manor's will twists around you, promising consequences.";
       default:
         return "You secure what you can from the chamber before returning to the corridor.";
     }

--- a/src/state/events.js
+++ b/src/state/events.js
@@ -1,0 +1,154 @@
+import {
+  EVENT_DEFINITIONS,
+  EVENT_MAP,
+  ROOM_EVENT_FLAVORS,
+  RELIC_DEFINITIONS,
+  RELIC_MAP,
+  MEMORY_MAP,
+} from "../data/index.js";
+import { filterDevDisabledEntries } from "./devtools.js";
+import { sampleWithoutReplacement } from "./random.js";
+import { getState } from "./state.js";
+import { addRelic, removeRelic, removeMemory } from "./inventory.js";
+
+function getFlavor(roomKey, eventKey) {
+  const roomData = ROOM_EVENT_FLAVORS?.[roomKey];
+  if (!roomData) {
+    return null;
+  }
+  return roomData?.[eventKey] || null;
+}
+
+export function createEventEncounter(roomKey, options = {}) {
+  const availableEvents = filterDevDisabledEntries("event", EVENT_DEFINITIONS);
+  if (!availableEvents || availableEvents.length === 0) {
+    return null;
+  }
+
+  let selected = null;
+  if (options?.eventKey) {
+    const explicit = EVENT_MAP.get(options.eventKey);
+    if (explicit) {
+      const available = filterDevDisabledEntries("event", [explicit]);
+      if (available.length > 0) {
+        selected = explicit;
+      }
+    }
+  }
+
+  if (!selected) {
+    const [choice] = sampleWithoutReplacement(availableEvents, 1);
+    selected = choice || availableEvents[0];
+  }
+
+  if (!selected) {
+    return null;
+  }
+
+  return {
+    type: "event",
+    key: selected.key,
+    definition: selected,
+    roomKey,
+    flavor: getFlavor(roomKey, selected.key),
+    resolved: false,
+    result: null,
+  };
+}
+
+function getOwnedRelics() {
+  const state = getState();
+  return Array.isArray(state.playerRelics) ? state.playerRelics.slice() : [];
+}
+
+function getOwnedMemories() {
+  const state = getState();
+  return Array.isArray(state.playerMemories) ? state.playerMemories.slice() : [];
+}
+
+export function awardRandomRelicFromEvent(eventEncounter, ctx) {
+  const definition = eventEncounter?.definition;
+  if (!definition) {
+    return { success: false, reason: "noDefinition" };
+  }
+  const count = Math.max(1, Number(definition.effect?.count) || 1);
+  const owned = new Set(getOwnedRelics());
+  const eligibleRelics = filterDevDisabledEntries(
+    "relic",
+    RELIC_DEFINITIONS
+  ).filter((relic) => relic && !owned.has(relic.key));
+  if (eligibleRelics.length === 0) {
+    return { success: false, reason: "noEligibleRelics" };
+  }
+  const selections = sampleWithoutReplacement(eligibleRelics, count);
+  const awarded = [];
+  selections.forEach((relic) => {
+    if (relic && addRelic(relic.key, ctx)) {
+      awarded.push(relic);
+      owned.add(relic.key);
+    }
+  });
+  if (awarded.length === 0) {
+    return { success: false, reason: "noEligibleRelics" };
+  }
+  return {
+    success: true,
+    relics: awarded,
+  };
+}
+
+export function getEventSacrificeOptions() {
+  const relicOptions = getOwnedRelics()
+    .map((key) => RELIC_MAP.get(key))
+    .filter(Boolean)
+    .map((relic) => ({ type: "relic", key: relic.key, name: relic.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const memoryOptions = getOwnedMemories()
+    .map((key) => MEMORY_MAP.get(key))
+    .filter(Boolean)
+    .map((memory) => ({ type: "memory", key: memory.key, name: memory.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return { relics: relicOptions, memories: memoryOptions };
+}
+
+export function sacrificeEventOffering(choice, ctx) {
+  if (!choice || !choice.key || !choice.type) {
+    return { success: false, reason: "invalidChoice" };
+  }
+  if (choice.type === "relic") {
+    const relic = RELIC_MAP.get(choice.key);
+    if (!relic) {
+      return { success: false, reason: "invalidChoice" };
+    }
+    const removed = removeRelic(relic.key, ctx);
+    if (!removed) {
+      return { success: false, reason: "removeFailed" };
+    }
+    return { success: true, type: "relic", key: relic.key, name: relic.name };
+  }
+  if (choice.type === "memory") {
+    const memory = MEMORY_MAP.get(choice.key);
+    if (!memory) {
+      return { success: false, reason: "invalidChoice" };
+    }
+    const removed = removeMemory(memory.key, ctx);
+    if (!removed) {
+      return { success: false, reason: "removeFailed" };
+    }
+    return { success: true, type: "memory", key: memory.key, name: memory.name };
+  }
+  return { success: false, reason: "invalidChoice" };
+}
+
+export function describeEventOutcome(eventEncounter, outcome) {
+  if (!eventEncounter || !eventEncounter.definition) {
+    return null;
+  }
+  const flavor = eventEncounter.flavor || getFlavor(eventEncounter.roomKey, eventEncounter.key);
+  if (!outcome?.success) {
+    return flavor?.failure || null;
+  }
+  return flavor?.resolution || null;
+}

--- a/src/state/inventory.js
+++ b/src/state/inventory.js
@@ -5,6 +5,8 @@ import {
   ensurePlayerConsumables,
   getState,
   recordMemory,
+  removeRelic as removeRelicState,
+  removeMemory as removeMemoryState,
 } from "./state.js";
 import { MAX_CONSUMABLE_SLOTS } from "./config.js";
 import {
@@ -144,6 +146,25 @@ export function addRelic(key, ctx) {
   return false;
 }
 
+export function removeRelic(key, ctx) {
+  if (!key) {
+    return false;
+  }
+  const context = resolveContext(ctx);
+  if (!removeRelicState(key)) {
+    context.showToast?.("That relic is no longer in your possession.");
+    return false;
+  }
+  const relic = RELIC_MAP.get(key);
+  if (context.showToast) {
+    context.showToast(
+      `The manor claims your relic: ${relic?.name || key}.`
+    );
+  }
+  notifyResourceUpdate(context);
+  return true;
+}
+
 export function addMemoryToState(key, ctx) {
   if (!key) {
     return false;
@@ -166,5 +187,24 @@ export function addMemoryToState(key, ctx) {
   if (memoryGold > 0) {
     addGold(memoryGold, context);
   }
+  return true;
+}
+
+export function removeMemory(key, ctx) {
+  if (!key) {
+    return false;
+  }
+  const context = resolveContext(ctx);
+  if (!removeMemoryState(key)) {
+    context.showToast?.("That memory is already lost.");
+    return false;
+  }
+  const memory = MEMORY_MAP.get(key);
+  if (context.showToast) {
+    context.showToast(
+      `The manor erases your memory: ${memory?.name || key}.`
+    );
+  }
+  notifyResourceUpdate(context);
   return true;
 }

--- a/src/state/run.js
+++ b/src/state/run.js
@@ -18,6 +18,7 @@ import {
   MERCHANT_BASE_DRAFT_COST,
 } from "./config.js";
 import { filterDevDisabledEntries } from "./devtools.js";
+import { createEventEncounter } from "./events.js";
 
 function buildInitialRoomPool() {
   return ROOM_DEFINITIONS.map((room) => room.key);
@@ -163,7 +164,12 @@ export async function goToRoom(ctx, roomKey, options = {}) {
     currentEncounterType: encounterType,
     currentRoomIsEnhanced: !!options.enhanced,
   });
-  const encounter = getEncounterForType(encounterType);
+  let encounter = null;
+  if (encounterType === "event") {
+    encounter = createEventEncounter(roomKey, options.eventOptions);
+  } else {
+    encounter = getEncounterForType(encounterType);
+  }
   updateState({ currentEncounter: encounter });
 
   await ctx.transitionTo("room", {

--- a/src/state/state.js
+++ b/src/state/state.js
@@ -130,6 +130,19 @@ export function awardRelic(key) {
   return true;
 }
 
+export function removeRelic(key) {
+  if (!key) {
+    return false;
+  }
+  const relics = ensurePlayerRelics();
+  const index = relics.indexOf(key);
+  if (index === -1) {
+    return false;
+  }
+  relics.splice(index, 1);
+  return true;
+}
+
 export function recordMemory(key) {
   if (!key) {
     return false;
@@ -139,6 +152,19 @@ export function recordMemory(key) {
     return false;
   }
   memories.push(key);
+  return true;
+}
+
+export function removeMemory(key) {
+  if (!key) {
+    return false;
+  }
+  const memories = ensurePlayerMemories();
+  const index = memories.indexOf(key);
+  if (index === -1) {
+    return false;
+  }
+  memories.splice(index, 1);
   return true;
 }
 

--- a/src/ui/codex.js
+++ b/src/ui/codex.js
@@ -10,6 +10,8 @@ import {
   MEMORY_DEFINITIONS,
   MEMORY_MAP,
   ENEMY_DEFINITIONS,
+  EVENT_DEFINITIONS,
+  EVENT_MAP,
 } from "../data/index.js";
 import { ACTION_DEFINITIONS } from "../combat/actions-data.js";
 import { ACTION_SEQUENCES } from "../combat/actions.js";
@@ -413,6 +415,71 @@ function buildConsumableEntriesFromKeys(keys = []) {
   return entries.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+function buildEventEntriesFromKeys(keys = []) {
+  const seen = new Set();
+  const entries = [];
+  keys.forEach((key) => {
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    const event = EVENT_MAP.get(key);
+    if (!event) {
+      return;
+    }
+    const detailParagraphs = [];
+    if (typeof event.summary === "string" && event.summary.trim().length > 0) {
+      detailParagraphs.push({
+        text: event.summary,
+        bindingSource: { object: event, path: ["summary"] },
+      });
+    }
+    if (Array.isArray(event.detailParagraphs)) {
+      event.detailParagraphs.forEach((paragraph, index) => {
+        if (typeof paragraph === "string" && paragraph.trim().length > 0) {
+          detailParagraphs.push({
+            text: paragraph,
+            bindingSource: { object: event.detailParagraphs, path: [index] },
+          });
+        }
+      });
+    }
+
+    const stats = [];
+    if (event.category) {
+      stats.push({ label: "Category", value: formatTitleCase(event.category) });
+    }
+    if (event.effect?.type) {
+      const effectLabel = formatTitleCase(
+        event.effect.type.replace(/([a-z])([A-Z])/g, "$1 $2")
+      );
+      stats.push({ label: "Effect", value: effectLabel || event.effect.type });
+    }
+    if (Number.isFinite(Number(event.effect?.count))) {
+      stats.push({
+        label: "Count",
+        value: Number(event.effect.count),
+        devBinding: createDevNumberBinding(event.effect, ["count"], {
+          min: 0,
+          step: 1,
+        }),
+      });
+    }
+
+    entries.push({
+      key: event.key,
+      type: "event",
+      name: event.name,
+      summary: event.summary || "",
+      detailParagraphs,
+      stats,
+      iconSymbol: event.name ? event.name.charAt(0).toUpperCase() : "E",
+    });
+  });
+
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
 function formatActionCostLine(cost) {
   if (!cost || typeof cost !== "object") {
     return "";
@@ -760,6 +827,7 @@ function renderCodexContent(target, options = {}) {
     enemyKeys = [],
     bossKeys = [],
     playerGhostKeys = [],
+    eventKeys = [],
     pages: customPages = [],
     emptyMessage = "No entries recorded in this ledger.",
   } = options;
@@ -772,6 +840,7 @@ function renderCodexContent(target, options = {}) {
   const enemyEntries = buildEnemyEntriesFromKeys(enemyKeys);
   const bossEntries = buildBossEntriesFromKeys(bossKeys);
   const playerGhostEntries = buildPlayerGhostEntriesFromKeys(playerGhostKeys);
+  const eventEntries = buildEventEntriesFromKeys(eventKeys);
 
   const entriesByType = {
     memory: memoryEntries,
@@ -781,6 +850,7 @@ function renderCodexContent(target, options = {}) {
     enemy: enemyEntries,
     boss: bossEntries,
     playerGhost: playerGhostEntries,
+    event: eventEntries,
   };
 
   const defaultSections = [
@@ -1188,6 +1258,7 @@ function renderCodexContent(target, options = {}) {
     enemy: "Enemies",
     boss: "Bosses",
     playerGhost: "Player Ghosts",
+    event: "Events",
   };
 
   function createSection(section, entries, pageIndex) {
@@ -1578,6 +1649,7 @@ export function showBestiary(ctx) {
         enemyKeys: enemySprites.map((sprite) => sprite.key),
         bossKeys: bossSprites.map((sprite) => sprite.key),
         playerGhostKeys: [playerCharacter.key],
+        eventKeys: EVENT_DEFINITIONS.map((event) => event.key),
         pages: BESTIARY_PAGES,
         emptyMessage: "Entries will appear here as development continues.",
       });

--- a/src/ui/screens/room.js
+++ b/src/ui/screens/room.js
@@ -7,6 +7,275 @@ import {
 import { createCombatExperience } from "../combat.js";
 import { createElement } from "../dom.js";
 import { updateState } from "../../state/state.js";
+import {
+  awardRandomRelicFromEvent,
+  describeEventOutcome,
+  getEventSacrificeOptions,
+  sacrificeEventOffering,
+} from "../../state/events.js";
+
+function formatList(items = []) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return "";
+  }
+  if (items.length === 1) {
+    return items[0];
+  }
+  const head = items.slice(0, -1);
+  const tail = items[items.length - 1];
+  return `${head.join(", ")} and ${tail}`;
+}
+
+function createEventEncounterUI(ctx, encounter) {
+  const container = createElement("div", "event-encounter");
+  const definition = encounter?.definition;
+  const flavor = encounter?.flavor;
+  const summaryText =
+    flavor?.description ||
+    definition?.summary ||
+    "The manor stirs in response to your presence.";
+  container.appendChild(createElement("p", "screen__subtitle", summaryText));
+
+  if (Array.isArray(definition?.detailParagraphs)) {
+    definition.detailParagraphs
+      .filter((text) => typeof text === "string" && text.trim().length > 0)
+      .forEach((text) => {
+        container.appendChild(
+          createElement("p", "combat-rewards__detail", text)
+        );
+      });
+  }
+
+  const footer = createElement("div", "screen-footer");
+  const continueButton = createElement(
+    "button",
+    "button button--primary",
+    "Return to the Corridor"
+  );
+  continueButton.addEventListener("click", async () => {
+    updateState({
+      currentRoomKey: null,
+      lastRunScreen: "corridor",
+      corridorRefreshes: 0,
+      currentEncounterType: null,
+      currentEncounter: null,
+    });
+    await ctx.transitionTo("corridor", { fromRoom: true });
+    ctx.showToast("You slip back into the corridor.");
+  });
+  footer.appendChild(continueButton);
+
+  const effectType = definition?.effect?.type;
+  if (effectType === "awardRandomRelic") {
+    let encounterState = encounter;
+    let outcome = encounterState?.result;
+    if (!encounterState?.resolved) {
+      outcome = awardRandomRelicFromEvent(encounterState, ctx);
+      encounterState = {
+        ...encounterState,
+        resolved: true,
+        result: outcome,
+      };
+      updateState({ currentEncounter: encounterState });
+    }
+
+    const resultWrapper = createElement("div", "event-encounter__results");
+    if (outcome?.success) {
+      const relicNames = Array.isArray(outcome.relics)
+        ? outcome.relics
+            .map((relic) => relic?.name)
+            .filter((name) => typeof name === "string" && name)
+        : [];
+      const rewardText = relicNames.length
+        ? `The manor grants you ${formatList(relicNames)}.`
+        : "The manor grants you a relic.";
+      resultWrapper.appendChild(
+        createElement("p", "combat-rewards__detail", rewardText)
+      );
+      const flavorText = describeEventOutcome(encounterState, outcome);
+      if (flavorText) {
+        resultWrapper.appendChild(
+          createElement("p", "combat-rewards__detail", flavorText)
+        );
+      }
+    } else {
+      const failureText =
+        describeEventOutcome(encounterState, outcome) ||
+        definition?.ui?.noEligibleText ||
+        "The manor has no further boons to share.";
+      resultWrapper.appendChild(
+        createElement("p", "combat-rewards__detail", failureText)
+      );
+    }
+    container.appendChild(resultWrapper);
+    continueButton.disabled = false;
+    return { container, footer };
+  }
+
+  if (effectType === "sacrificeRelicOrMemory") {
+    let encounterState = encounter;
+    const resultWrapper = createElement("div", "event-encounter__results");
+    const selectionNotice = definition?.ui?.choosePrompt;
+    if (!encounterState?.resolved) {
+      const options = getEventSacrificeOptions();
+      const combined = [...options.relics, ...options.memories];
+      if (combined.length === 0) {
+        const failureOutcome = { success: false, reason: "noOptions" };
+        const failureText =
+          describeEventOutcome(encounterState, failureOutcome) ||
+          definition?.ui?.nothingToLoseText ||
+          "The manor finds nothing to claim.";
+        resultWrapper.appendChild(
+          createElement("p", "combat-rewards__detail", failureText)
+        );
+        encounterState = {
+          ...encounterState,
+          resolved: true,
+          result: failureOutcome,
+        };
+        updateState({ currentEncounter: encounterState });
+        continueButton.disabled = false;
+        container.appendChild(resultWrapper);
+        return { container, footer };
+      }
+
+      if (selectionNotice) {
+        container.appendChild(
+          createElement("p", "combat-rewards__detail", selectionNotice)
+        );
+      }
+
+      const form = createElement("form", "event-encounter__form");
+      const list = createElement("ul", "event-encounter__choices");
+      let selectedKey = null;
+      let selectedType = null;
+
+      combined.forEach((option, index) => {
+        const item = createElement("li", "event-encounter__choice");
+        const inputId = `event-choice-${option.type}-${option.key}`;
+        const label = createElement("label", "event-encounter__label");
+        label.setAttribute("for", inputId);
+        const input = document.createElement("input");
+        input.type = "radio";
+        input.name = "eventOffering";
+        input.id = inputId;
+        input.value = option.key;
+        input.dataset.type = option.type;
+        if (index === 0) {
+          input.checked = true;
+          selectedKey = option.key;
+          selectedType = option.type;
+        }
+        input.addEventListener("change", () => {
+          selectedKey = input.value;
+          selectedType = input.dataset.type;
+        });
+        const labelText =
+          option.type === "memory"
+            ? `Memory: ${option.name}`
+            : `Relic: ${option.name}`;
+        label.appendChild(input);
+        label.appendChild(document.createTextNode(labelText));
+        item.appendChild(label);
+        list.appendChild(item);
+      });
+
+      form.appendChild(list);
+      const confirmButton = createElement(
+        "button",
+        "button button--primary",
+        definition?.ui?.confirmLabel || "Offer This Tribute"
+      );
+      confirmButton.type = "button";
+      confirmButton.addEventListener("click", () => {
+        if (!selectedKey || !selectedType) {
+          ctx.showToast?.("Select an offering for the manor.");
+          return;
+        }
+        const outcome = sacrificeEventOffering(
+          { key: selectedKey, type: selectedType },
+          ctx
+        );
+        if (!outcome?.success) {
+          ctx.showToast?.("The manor rejects your attempt.");
+          return;
+        }
+        encounterState = {
+          ...encounterState,
+          resolved: true,
+          result: outcome,
+        };
+        updateState({ currentEncounter: encounterState });
+        confirmButton.disabled = true;
+        form.querySelectorAll("input").forEach((input) => {
+          input.disabled = true;
+        });
+        continueButton.disabled = false;
+        const sacrificeLabel =
+          outcome.type === "memory" ? "memory" : "relic";
+        resultWrapper.appendChild(
+          createElement(
+            "p",
+            "combat-rewards__detail",
+            `You surrender the ${sacrificeLabel}: ${outcome.name}.`
+          )
+        );
+        const flavorText = describeEventOutcome(encounterState, outcome);
+        if (flavorText) {
+          resultWrapper.appendChild(
+            createElement("p", "combat-rewards__detail", flavorText)
+          );
+        }
+      });
+
+      form.appendChild(confirmButton);
+      container.appendChild(form);
+      container.appendChild(resultWrapper);
+      continueButton.disabled = true;
+      return { container, footer };
+    }
+
+    const finalOutcome = encounterState?.result;
+    if (finalOutcome?.success) {
+      const sacrificeLabel =
+        finalOutcome.type === "memory" ? "memory" : "relic";
+      resultWrapper.appendChild(
+        createElement(
+          "p",
+          "combat-rewards__detail",
+          `You surrender the ${sacrificeLabel}: ${finalOutcome.name}.`
+        )
+      );
+      const flavorText = describeEventOutcome(encounterState, finalOutcome);
+      if (flavorText) {
+        resultWrapper.appendChild(
+          createElement("p", "combat-rewards__detail", flavorText)
+        );
+      }
+    } else {
+      const failureText =
+        describeEventOutcome(encounterState, finalOutcome) ||
+        definition?.ui?.nothingToLoseText ||
+        "The manor finds nothing to claim.";
+      resultWrapper.appendChild(
+        createElement("p", "combat-rewards__detail", failureText)
+      );
+    }
+    container.appendChild(resultWrapper);
+    continueButton.disabled = false;
+    return { container, footer };
+  }
+
+  container.appendChild(
+    createElement(
+      "p",
+      "combat-rewards__detail",
+      "The manor hesitates, unsure of how to proceed."
+    )
+  );
+  continueButton.disabled = false;
+  return { container, footer };
+}
 
 const roomScreen = {
   key: "room",
@@ -14,7 +283,8 @@ const roomScreen = {
     const roomData = ctx.options?.room;
     const encounterType =
       ctx.options?.encounterType || ctx.state.currentEncounterType;
-    const encounter = ctx.options?.encounter || ctx.state.currentEncounter;
+    const encounter =
+      ctx.state.currentEncounter || ctx.options?.encounter || null;
     const wrapper = createElement("div", "screen screen--room");
     const roomNumber = Math.max(ctx.state.currentRoomNumber, 1);
     const tracker = ctx.helpers?.createRunTracker?.(
@@ -72,6 +342,18 @@ const roomScreen = {
     if (encounterScene) {
       wrapper.append(encounterScene.scene);
     }
+
+    if (encounterType === "event") {
+      const eventExperience = createEventEncounterUI(ctx, encounter);
+      if (eventExperience?.container) {
+        wrapper.appendChild(eventExperience.container);
+      }
+      if (eventExperience?.footer) {
+        wrapper.appendChild(eventExperience.footer);
+      }
+      return wrapper;
+    }
+
     const prompt = createElement(
       "p",
       "screen__subtitle",

--- a/styles.css
+++ b/styles.css
@@ -1698,6 +1698,47 @@ button {
   color: var(--color-muted);
 }
 
+.event-encounter {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.event-encounter__form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.event-encounter__choices {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.event-encounter__choice {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.event-encounter__label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 500;
+}
+
+.event-encounter__label input[type="radio"] {
+  accent-color: var(--color-aether, #9ea6ff);
+}
+
+.event-encounter__results {
+  display: grid;
+  gap: 0.75rem;
+}
+
 .combat-rewards__actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- define base manor events with room-specific flavor descriptions
- implement event handling flows for random relic gifts and sacrifice demands, including inventory updates and corridor integration
- surface events in the room UI with custom styling and expose them in the bestiary for developer toggling

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf23183370832cb07b26df20c4603e