### PR TITLE
Support multi-foe encounters and corridor refresh drain

### DIFF
--- a/src/combat/actions-data.js
+++ b/src/combat/actions-data.js
@@ -3,6 +3,7 @@ import {
   dealDamage,
   duplicateRandomActionSlot,
   getActionApCost,
+  getPrimaryEnemy,
   hasStatus,
   healCombatant,
   logCombat,
@@ -137,7 +138,7 @@ const ACTION_DEFINITIONS = {
     facingEffect(combat) {
       combat.player.temp.retaliateDamage += 2;
     },
-    effect: ({ combat, actor }) => {
+    effect: ({ combat, actor, target }) => {
       const passives = actor === combat.player ? combat.player.passives || {} : {};
       const blockBonus = passives.guardBlockBonus || 0;
       const blockAmount = 6 + blockBonus;
@@ -154,7 +155,7 @@ const ACTION_DEFINITIONS = {
     baseDamage: 0,
     description: "Gain Armor (2) and Block (6).",
     chain: { key: "fearCore", index: 1 },
-    effect: ({ combat, actor }) => {
+    effect: ({ combat, actor, target }) => {
       actor.block = (actor.block || 0) + 6;
       applyStatus(actor, "armor", 2, { duration: 2 });
       logCombat(combat, `${actor.name} braces behind solid defenses.`);
@@ -210,7 +211,7 @@ const ACTION_DEFINITIONS = {
     facingEffect(combat) {
       combat.player.temp.retaliateDamage += 3;
     },
-    effect: ({ combat, actor }) => {
+    effect: ({ combat, actor, target }) => {
       actor.block = (actor.block || 0) + 10;
       logCombat(combat, `${actor.name} shelters behind a tower shield (Block 10).`);
     },
@@ -709,7 +710,7 @@ const ACTION_DEFINITIONS = {
     type: "attack",
     baseDamage: 0,
     description: "Copy the last action at +1 AP cost and −20% damage.",
-    effect: ({ combat, actor }) => {
+    effect: ({ combat, actor, target }) => {
       const last = actor.flags?.lastAction;
       if (!last) {
         logCombat(combat, "There is no action to echo.");
@@ -720,7 +721,7 @@ const ACTION_DEFINITIONS = {
         logCombat(combat, "The last action cannot be echoed.");
         return { cancel: true };
       }
-      const baseCost = getActionApCost(combat, action);
+      const baseCost = getActionApCost(combat, action, target);
       const totalCost = baseCost + 1;
       if (totalCost > actor.ap) {
         logCombat(combat, "You lack the AP to echo that memory.");
@@ -730,7 +731,7 @@ const ACTION_DEFINITIONS = {
       combat.player.flags = combat.player.flags || {};
       combat.player.flags.echoDamageModifier = 0.8;
       combat.player.flags.echoActive = true;
-      action.effect?.({ combat, actor, target: combat.enemy, slot: null });
+      action.effect?.({ combat, actor, target: target || getPrimaryEnemy(combat), slot: null });
       combat.player.history.push({ key: action.key, name: `${action.name} (Echo)` });
       combat.player.flags.echoActive = false;
       combat.player.flags.echoDamageModifier = 1;

--- a/src/combat/engine.js
+++ b/src/combat/engine.js
@@ -127,6 +127,60 @@ function cloneEnemyMoves(moves, multiplier) {
   }));
 }
 
+function getEncounterEnemyEntries(encounter) {
+  if (Array.isArray(encounter?.enemies) && encounter.enemies.length > 0) {
+    return encounter.enemies;
+  }
+  if (encounter?.sprite) {
+    return [{ sprite: encounter.sprite }];
+  }
+  return [];
+}
+
+function createEnemyId(index) {
+  return `enemy-${index + 1}`;
+}
+
+function getLivingEnemies(combat) {
+  if (!combat || !Array.isArray(combat.enemies)) {
+    return [];
+  }
+  return combat.enemies.filter((enemy) => enemy && enemy.essence > 0);
+}
+
+function findEnemyById(combat, enemyId) {
+  if (!combat || !Array.isArray(combat.enemies)) {
+    return null;
+  }
+  return combat.enemies.find((enemy) => enemy && enemy.id === enemyId) || null;
+}
+
+function getPrimaryEnemy(combat) {
+  const living = getLivingEnemies(combat);
+  if (living.length > 0) {
+    return living[0];
+  }
+  return Array.isArray(combat.enemies) ? combat.enemies[0] || null : null;
+}
+
+function areAllEnemiesDefeated(combat) {
+  return getLivingEnemies(combat).length === 0;
+}
+
+function actionRequiresEnemyTarget(action) {
+  if (!action) {
+    return false;
+  }
+  if (action.requiresTarget === false) {
+    return false;
+  }
+  if (action.requiresTarget === true) {
+    return true;
+  }
+  const nonTargetTypes = new Set(["buff", "heal", "support"]);
+  return !nonTargetTypes.has(action.type || "");
+}
+
 export function createCombatState(ctx, { encounterType, encounter, room }) {
   ensureDefaultMemories(ctx);
   const memoryKeys = Array.isArray(ctx.state.playerMemories)
@@ -169,35 +223,58 @@ export function createCombatState(ctx, { encounterType, encounter, room }) {
   };
   resetTempStats(player);
 
-  const sprite = encounter?.sprite || {};
-  const enemyDefinition = ENEMY_DEFINITIONS[sprite.key] || {
-    maxEssence: 12,
-    moves: DEFAULT_ENEMY_MOVES,
-  };
   const multiplier = getEncounterScaling(encounterType);
-  const baseEnemyEssence = enemyDefinition.maxEssence || 12;
-  const scaledEnemyEssence = Math.max(1, scaleValue(baseEnemyEssence, multiplier));
-  const adjustedEnemyEssence =
-    encounterType === "boss"
-      ? Math.max(1, Math.round(scaledEnemyEssence / 2))
-      : scaledEnemyEssence;
+  const enemyEntries = getEncounterEnemyEntries(encounter);
+  const enemies = enemyEntries.map((entry, index) => {
+    const sprite = entry?.sprite || {};
+    const definition = ENEMY_DEFINITIONS[sprite.key] || {
+      maxEssence: 12,
+      moves: DEFAULT_ENEMY_MOVES,
+    };
+    const baseEnemyEssence = definition.maxEssence || 12;
+    const scaledEnemyEssence = Math.max(1, scaleValue(baseEnemyEssence, multiplier));
+    const adjustedEnemyEssence =
+      encounterType === "boss"
+        ? Math.max(1, Math.round(scaledEnemyEssence / 2))
+        : scaledEnemyEssence;
+    const enemy = {
+      id: entry?.id || createEnemyId(index),
+      side: "enemy",
+      name: sprite.name || `Hostile Spirit ${index + 1}`,
+      maxEssence: adjustedEnemyEssence,
+      essence: adjustedEnemyEssence,
+      statuses: {},
+      block: 0,
+      armor: 0,
+      history: [],
+      flags: {},
+      moves: cloneEnemyMoves(definition.moves, multiplier),
+      moveIndex: 0,
+      sprite,
+    };
+    resetTempStats(enemy);
+    return enemy;
+  });
 
-  const enemy = {
-    id: "enemy",
-    side: "enemy",
-    name: sprite.name || "Hostile Spirit",
-    maxEssence: adjustedEnemyEssence,
-    essence: adjustedEnemyEssence,
-    statuses: {},
-    block: 0,
-    armor: 0,
-    history: [],
-    flags: {},
-    moves: cloneEnemyMoves(enemyDefinition.moves, multiplier),
-    moveIndex: 0,
-    sprite,
-  };
-  resetTempStats(enemy);
+  if (enemies.length === 0) {
+    const fallback = {
+      id: createEnemyId(0),
+      side: "enemy",
+      name: "Hostile Spirit",
+      maxEssence: 12,
+      essence: 12,
+      statuses: {},
+      block: 0,
+      armor: 0,
+      history: [],
+      flags: {},
+      moves: cloneEnemyMoves(DEFAULT_ENEMY_MOVES, multiplier),
+      moveIndex: 0,
+      sprite: {},
+    };
+    resetTempStats(fallback);
+    enemies.push(fallback);
+  }
 
   return {
     ctx,
@@ -205,7 +282,7 @@ export function createCombatState(ctx, { encounterType, encounter, room }) {
     encounterType,
     encounter,
     player,
-    enemy,
+    enemies,
     soup,
     actionSlots: new Array(slotCount).fill(null),
     log: [],
@@ -218,9 +295,20 @@ export function createCombatState(ctx, { encounterType, encounter, room }) {
 }
 
 export function startCombat(combat) {
+  const enemyNames = getLivingEnemies(combat).map((enemy) => enemy.name);
+  let foeDescription = "A spectral foe";
+  if (enemyNames.length === 1) {
+    foeDescription = enemyNames[0];
+  } else if (enemyNames.length > 1) {
+    const head = enemyNames.slice(0, -1);
+    const tail = enemyNames[enemyNames.length - 1];
+    foeDescription = `${head.join(", ")} and ${tail}`;
+  }
   logCombat(
     combat,
-    `${combat.enemy.name} prepares to fight within ${combat.room?.name || "the chamber"}.`
+    `${foeDescription} prepare${enemyNames.length === 1 ? "s" : ""} to fight within ${
+      combat.room?.name || "the chamber"
+    }.`
   );
   updateCombatUI(combat);
   startPlayerTurn(combat);
@@ -426,7 +514,7 @@ function applyFacingEffects(combat) {
   }
 }
 
-export function getActionApCost(combat, action) {
+export function getActionApCost(combat, action, target = null) {
   if (!action || !action.cost) {
     return 0;
   }
@@ -443,7 +531,7 @@ export function getActionApCost(combat, action) {
   if (
     action.key === "breakthrough" &&
     combat.player.passives.breakthroughFatigueDiscount &&
-    hasStatus(combat.enemy, "fatigue")
+    hasStatus(target || getPrimaryEnemy(combat), "fatigue")
   ) {
     cost = Math.max(0, cost - combat.player.passives.breakthroughFatigueDiscount);
   }
@@ -469,7 +557,7 @@ export function getActionEssenceCost(combat, action) {
   return Math.max(0, cost);
 }
 
-export function performPlayerAction(combat, slotIndex) {
+export function performPlayerAction(combat, slotIndex, targetId = null) {
   if (combat.status !== "inProgress" || combat.turn !== "player") {
     return;
   }
@@ -485,7 +573,19 @@ export function performPlayerAction(combat, slotIndex) {
     logCombat(combat, "That action has been disabled in developer tools.");
     return;
   }
-  const apCost = getActionApCost(combat, action);
+  const requiresTarget = actionRequiresEnemyTarget(action);
+  let target = null;
+  if (requiresTarget) {
+    target = findEnemyById(combat, targetId) || getPrimaryEnemy(combat);
+    if (!target || target.essence <= 0) {
+      logCombat(combat, "There is no viable enemy to target.");
+      return;
+    }
+  } else {
+    target = findEnemyById(combat, targetId) || getPrimaryEnemy(combat);
+  }
+
+  const apCost = getActionApCost(combat, action, target);
   const essenceCost = getActionEssenceCost(combat, action);
 
   if (apCost > combat.player.ap) {
@@ -508,7 +608,7 @@ export function performPlayerAction(combat, slotIndex) {
     ? action.effect({
         combat,
         actor: combat.player,
-        target: combat.enemy,
+        target: target || getPrimaryEnemy(combat),
         slot,
         apCost,
       })
@@ -569,7 +669,7 @@ export function performPlayerAction(combat, slotIndex) {
     action.effect?.({
       combat,
       actor: combat.player,
-      target: combat.enemy,
+      target: target || getPrimaryEnemy(combat),
       slot,
       apCost,
     });
@@ -578,7 +678,7 @@ export function performPlayerAction(combat, slotIndex) {
 
   advanceSlotChain(combat, slot, action, slotIndex);
 
-  if (combat.enemy.essence <= 0) {
+  if (areAllEnemiesDefeated(combat)) {
     handleVictory(combat);
     return;
   }
@@ -677,40 +777,57 @@ function startEnemyTurn(combat) {
   combat.turn = "enemy";
   combat.player.flags = combat.player.flags || {};
   combat.player.flags.blockedDamageThisTurn = 0;
-  applyStartOfTurnStatuses(combat, combat.enemy, "enemy");
-  const pendingDaze =
-    getStatusStacks(combat.enemy, "dazed") + (combat.enemy.flags?.pendingDaze || 0);
-  if (pendingDaze > 0) {
-    combat.enemy.flags = combat.enemy.flags || {};
-    combat.enemy.flags.stalled = (combat.enemy.flags.stalled || 0) + pendingDaze;
-    removeStatus(combat.enemy, "dazed");
-    combat.enemy.flags.pendingDaze = 0;
-    logCombat(
-      combat,
-      `${combat.enemy.name} is dazed and loses ${pendingDaze} action${
-        pendingDaze === 1 ? "" : "s"
-      }.`
-    );
-  }
-  if (combat.enemy.essence <= 0) {
+
+  const activeEnemies = getLivingEnemies(combat);
+  if (activeEnemies.length === 0) {
     handleVictory(combat);
     return;
   }
-  if (combat.enemy.flags.stalled) {
-    combat.enemy.flags.stalled -= 1;
-    logCombat(combat, `${combat.enemy.name} hesitates and loses their turn.`);
-    endEnemyTurn(combat);
-    return;
+
+  for (const enemy of activeEnemies) {
+    if (combat.status !== "inProgress") {
+      break;
+    }
+    applyStartOfTurnStatuses(combat, enemy, "enemy");
+    if (enemy.essence <= 0) {
+      continue;
+    }
+    const pendingDaze =
+      getStatusStacks(enemy, "dazed") + (enemy.flags?.pendingDaze || 0);
+    if (pendingDaze > 0) {
+      enemy.flags = enemy.flags || {};
+      enemy.flags.stalled = (enemy.flags.stalled || 0) + pendingDaze;
+      removeStatus(enemy, "dazed");
+      enemy.flags.pendingDaze = 0;
+      logCombat(
+        combat,
+        `${enemy.name} is dazed and loses ${pendingDaze} action${
+          pendingDaze === 1 ? "" : "s"
+        }.`
+      );
+    }
+    if (enemy.essence <= 0) {
+      continue;
+    }
+    if (enemy.flags?.stalled) {
+      enemy.flags.stalled -= 1;
+      logCombat(combat, `${enemy.name} hesitates and loses their turn.`);
+      continue;
+    }
+    performEnemyMove(combat, enemy);
   }
-  performEnemyMove(combat);
+
   if (combat.status !== "inProgress") {
     return;
   }
+
   endEnemyTurn(combat);
 }
 
-function performEnemyMove(combat) {
-  const enemy = combat.enemy;
+function performEnemyMove(combat, enemy) {
+  if (!enemy || enemy.essence <= 0) {
+    return;
+  }
   if (!enemy.moves || enemy.moves.length === 0) {
     logCombat(combat, `${enemy.name} struggles to act.`);
     return;
@@ -767,7 +884,11 @@ function performEnemyMove(combat) {
 }
 
 function endEnemyTurn(combat) {
-  applyEndOfTurnStatuses(combat, combat.enemy);
+  if (Array.isArray(combat.enemies)) {
+    combat.enemies.forEach((enemy) => {
+      applyEndOfTurnStatuses(combat, enemy);
+    });
+  }
   combat.round += 1;
   combat.turn = "player";
   updateCombatUI(combat);
@@ -1799,7 +1920,14 @@ function handleVictory(combat) {
     return;
   }
   combat.status = "victory";
-  logCombat(combat, `${combat.enemy.name} collapses. You are victorious!`);
+  const enemyNames = Array.isArray(combat.enemies)
+    ? combat.enemies.map((enemy) => enemy?.name).filter(Boolean)
+    : [];
+  if (enemyNames.length === 1) {
+    logCombat(combat, `${enemyNames[0]} collapses. You are victorious!`);
+  } else {
+    logCombat(combat, "The last of your foes collapses. You are victorious!");
+  }
   if (combat.ctx?.state) {
     const encounterType =
       combat.encounterType ||
@@ -1876,6 +2004,11 @@ export function dealDamage(combat, actor, target, amount, options = {}) {
   const passives = combat.player?.passives || {};
   const actionDef = options.actionKey ? ACTION_DEFINITIONS[options.actionKey] : null;
   let actionApCost = options.apCost;
+  const panelGetter = combat.dom?.getPanelForCombatant;
+  const getPanelFor = (combatant) =>
+    typeof panelGetter === "function"
+      ? panelGetter(combatant)
+      : combat.dom?.[`${combatant.side}Panel`];
   if (
     typeof actionApCost === "undefined" &&
     actionDef &&
@@ -1918,7 +2051,7 @@ export function dealDamage(combat, actor, target, amount, options = {}) {
   if (target.statuses?.dodge) {
     target.statuses.dodge -= 1;
     logCombat(combat, `${target.name} dodges the attack.`);
-    showFloatingText(combat, combat.dom[`${target.side}Panel`], "Dodge", "info");
+    showFloatingText(combat, getPanelFor(target), "Dodge", "info");
     attackMissed = true;
   }
 
@@ -1951,13 +2084,14 @@ export function dealDamage(combat, actor, target, amount, options = {}) {
           const stacks = Math.max(1, passives.blockThresholdDazeStacks || 1);
           while (combat.player.flags.blockedDamageThisTurn >= threshold) {
             combat.player.flags.blockedDamageThisTurn -= threshold;
-            applyStatus(combat.enemy, "dazed", stacks, { duration: 1 });
-            combat.enemy.flags = combat.enemy.flags || {};
-            combat.enemy.flags.pendingDaze =
-              (combat.enemy.flags.pendingDaze || 0) + stacks;
+            if (actor && actor.side === "enemy") {
+              applyStatus(actor, "dazed", stacks, { duration: 1 });
+              actor.flags = actor.flags || {};
+              actor.flags.pendingDaze = (actor.flags.pendingDaze || 0) + stacks;
+            }
             logCombat(
               combat,
-              `Porcelain Rat startles ${combat.enemy.name}, applying Dazed (${stacks}).`
+              `Porcelain Rat startles ${actor?.name || "the foe"}, applying Dazed (${stacks}).`
             );
           }
         }
@@ -1984,7 +2118,7 @@ export function dealDamage(combat, actor, target, amount, options = {}) {
   target.essence = Math.max(0, target.essence - damage);
   showFloatingText(
     combat,
-    combat.dom[`${target.side}Panel`],
+    getPanelFor(target),
     `${damage}${isCrit ? "!" : ""}`,
     actor === combat.player ? "damage" : "enemy"
   );
@@ -2021,7 +2155,9 @@ export function dealDamage(combat, actor, target, amount, options = {}) {
 
   if (target.essence <= 0) {
     if (target.side === "enemy") {
-      handleVictory(combat);
+      if (areAllEnemiesDefeated(combat)) {
+        handleVictory(combat);
+      }
     } else {
       handleDefeat(combat);
     }
@@ -2051,9 +2187,14 @@ export function healCombatant(combat, combatant, amount) {
   combatant.essence = Math.min(combatant.maxEssence, combatant.essence + amount);
   if (combat && combat.log) {
     logCombat(combat, `${combatant.name} recovers ${amount} essence.`);
+    const panelGetter = combat.dom?.getPanelForCombatant;
+    const panel =
+      typeof panelGetter === "function"
+        ? panelGetter(combatant)
+        : combat.dom?.[`${combatant.side}Panel`];
     showFloatingText(
       combat,
-      combat.dom[`${combatant.side}Panel`],
+      panel,
       `+${amount}`,
       "heal"
     );
@@ -2115,7 +2256,7 @@ function applyStartOfTurnStatuses(combat, combatant, side) {
     logCombat(combat, `${combatant.name} bleeds for ${bleedDamage}.`);
     dealDamage(
       combat,
-      side === "enemy" ? combat.player : combat.enemy,
+      side === "enemy" ? combat.player : getPrimaryEnemy(combat),
       combatant,
       bleedDamage,
       { source: "Bleed" }
@@ -2242,4 +2383,7 @@ export {
   applyRecoveryRoomBenefits,
   createRewardsPanel,
   createMerchantPanel,
+  findEnemyById,
+  getLivingEnemies,
+  getPrimaryEnemy,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -384,28 +384,42 @@ import { initializeDebugLogUI } from "./ui/debug-log.js";
     );
     let encounterElement = null;
 
-    if (encounter && encounter.sprite) {
-      const shouldAnimate = encounter.animate && !shouldReduceMotion();
-      const encounterCharacter = createCharacterElement(encounter.sprite, {
-        role: "encounter",
-        animate: shouldAnimate,
-      });
-      if (encounterCharacter) {
-        encounterElement = encounterCharacter.element;
-        encounterSide.appendChild(encounterElement);
+    const sprites = Array.isArray(encounter?.enemies)
+      ? encounter.enemies
+          .map((entry) => entry?.sprite)
+          .filter((sprite) => sprite && sprite.src)
+      : encounter?.sprite
+      ? [encounter.sprite]
+      : [];
+
+    if (sprites.length > 0) {
+      const shouldAnimate = encounter?.animate && !shouldReduceMotion();
+      sprites.forEach((sprite, index) => {
+        const encounterCharacter = createCharacterElement(sprite, {
+          role: "encounter",
+          animate: shouldAnimate,
+        });
+        if (!encounterCharacter) {
+          return;
+        }
+        const element = encounterCharacter.element;
+        encounterSide.appendChild(element);
+        if (!encounterElement) {
+          encounterElement = element;
+        }
         if (shouldAnimate) {
           window.setTimeout(() => {
-            if (encounterElement && encounterElement.isConnected) {
-              encounterElement.classList.add("is-visible");
+            if (element && element.isConnected) {
+              element.classList.add("is-visible");
             }
-          }, Math.max(0, Number(encounter.enterDelay) || 2000));
+          }, Math.max(0, Number(encounter.enterDelay) || 2000) + index * 150);
         }
+      });
+      if (sprites.length === 1) {
+        scene.classList.add("room-scene--solo");
       }
     } else {
       encounterSide.classList.add("room-scene__side--empty");
-    }
-
-    if (!encounterElement) {
       scene.classList.add("room-scene--solo");
     }
 

--- a/src/state/run.js
+++ b/src/state/run.js
@@ -12,7 +12,7 @@ import {
   clearCodexView,
   updateState,
 } from "./state.js";
-import { sampleWithoutReplacement } from "./random.js";
+import { getRandomItem, sampleWithoutReplacement } from "./random.js";
 import {
   DEFAULT_PLAYER_STATS,
   MERCHANT_BASE_DRAFT_COST,
@@ -113,20 +113,37 @@ export function getEncounterForType(type) {
   if (!pool) {
     return null;
   }
+  const animatedTypes = new Set(["combat", "elite", "boss"]);
+  if (type === "combat" || type === "elite" || type === "boss") {
+    const desiredCount = type === "boss" ? 3 : type === "elite" ? 2 : 1;
+    const enemies = [];
+    for (let i = 0; i < desiredCount; i += 1) {
+      const sprite = getRandomItem(pool);
+      if (!sprite) {
+        break;
+      }
+      enemies.push({ sprite });
+    }
+    if (enemies.length === 0) {
+      return null;
+    }
+    return {
+      type,
+      enemies,
+      sprite: enemies[0]?.sprite || null,
+      kind: type === "boss" ? "boss" : "enemy",
+      animate: animatedTypes.has(type),
+      enterDelay: 2000,
+    };
+  }
   const [sprite] = sampleWithoutReplacement(pool, 1);
   if (!sprite) {
     return null;
   }
-  const animatedTypes = new Set(["combat", "elite", "boss"]);
   return {
     sprite,
     type,
-    kind:
-      type === "merchant"
-        ? "merchant"
-        : type === "boss"
-        ? "boss"
-        : "enemy",
+    kind: type === "merchant" ? "merchant" : "enemy",
     animate: animatedTypes.has(type),
     enterDelay: 2000,
   };

--- a/src/ui/combat.js
+++ b/src/ui/combat.js
@@ -14,7 +14,7 @@ import { setActiveCombat, updateState } from '../state/state.js';
 import { isDevEntryDisabled } from '../state/devtools.js';
 import { createElement } from './dom.js';
 
-function createCombatantDisplay(combatant, role, encounter) {
+function createCombatantDisplay(combatant, role, spriteSource) {
   const container = createElement(
     'div',
     `combatant-card combatant-card--${role}`
@@ -24,17 +24,13 @@ function createCombatantDisplay(combatant, role, encounter) {
   avatar.dataset.role = role;
   container.appendChild(avatar);
 
-  const spriteSource =
-    role === 'enemy'
-      ? encounter?.sprite
-      : role === 'player'
-      ? playerCharacter
-      : null;
-  if (spriteSource?.src) {
+  const resolvedSprite = role === 'player' ? playerCharacter : spriteSource;
+
+  if (resolvedSprite?.src) {
     const image = document.createElement('img');
     image.className = 'combatant-card__sprite';
-    image.src = spriteSource.src;
-    image.alt = spriteSource.alt || combatant.name;
+    image.src = resolvedSprite.src;
+    image.alt = resolvedSprite.alt || combatant.name;
     image.loading = role === 'player' ? 'eager' : 'lazy';
     image.decoding = 'async';
     avatar.appendChild(image);
@@ -46,8 +42,8 @@ function createCombatantDisplay(combatant, role, encounter) {
   const stats = createElement('div', 'combatant-card__stats');
   container.appendChild(stats);
 
-  if (role === 'enemy' && encounter?.sprite) {
-    avatar.dataset.sprite = encounter.sprite.key || 'enemy';
+  if (role === 'enemy' && resolvedSprite) {
+    avatar.dataset.sprite = resolvedSprite.key || 'enemy';
   }
 
   const statusList = createElement('div', 'combatant-card__statuses');
@@ -56,9 +52,86 @@ function createCombatantDisplay(combatant, role, encounter) {
   return { container, avatar, stats, statusList };
 }
 
+function requiresEnemyTarget(action) {
+  if (!action) {
+    return false;
+  }
+  if (action.requiresTarget === false) {
+    return false;
+  }
+  if (action.requiresTarget === true) {
+    return true;
+  }
+  const nonTargetTypes = new Set(['buff', 'heal', 'support']);
+  return !nonTargetTypes.has(action.type || '');
+}
+
+function forEachEnemyDisplay(combat, callback) {
+  if (!combat?.dom?.enemyDisplays || !(combat.dom.enemyDisplays instanceof Map)) {
+    return;
+  }
+  combat.dom.enemyDisplays.forEach((display, enemyId) => {
+    callback(display, enemyId);
+  });
+}
+
+function cancelTargetSelection(combat) {
+  if (!combat) {
+    return;
+  }
+  combat.targeting = null;
+  if (combat.dom?.container) {
+    combat.dom.container.classList.remove('combat--targeting');
+  }
+  forEachEnemyDisplay(combat, (display) => {
+    display.container.classList.remove('combatant-card--targetable');
+    display.container.classList.remove('combatant-card--untargetable');
+  });
+  updateActionButtons(combat);
+}
+
+function beginTargetSelection(combat, slotIndex, action) {
+  if (!combat?.dom?.container) {
+    return;
+  }
+  const hasAliveEnemy = Array.isArray(combat.enemies)
+    ? combat.enemies.some((enemy) => enemy && enemy.essence > 0)
+    : false;
+  if (!hasAliveEnemy) {
+    combat.ctx?.showToast?.('No enemies remain to target.');
+    return;
+  }
+  combat.targeting = { slotIndex, actionKey: action?.key || null };
+  combat.dom.container.classList.add('combat--targeting');
+  forEachEnemyDisplay(combat, (display, enemyId) => {
+    const enemy = combat.enemies?.find((entry) => entry.id === enemyId);
+    const alive = enemy ? enemy.essence > 0 : false;
+    display.container.classList.toggle('combatant-card--targetable', alive);
+    display.container.classList.toggle('combatant-card--untargetable', !alive);
+  });
+  updateActionButtons(combat);
+  combat.ctx?.showToast?.('Select a target.');
+}
+
+function handleEnemyTargetSelection(combat, enemyId) {
+  if (!combat?.targeting) {
+    return;
+  }
+  const enemy = combat.enemies?.find((entry) => entry.id === enemyId);
+  if (!enemy || enemy.essence <= 0) {
+    combat.ctx?.showToast?.('That foe is already defeated.');
+    cancelTargetSelection(combat);
+    return;
+  }
+  const slotIndex = combat.targeting.slotIndex;
+  cancelTargetSelection(combat);
+  performPlayerAction(combat, slotIndex, enemyId);
+}
+
 function createCombatExperience(ctx, { room, encounterType, encounter }) {
   const combat = createCombatState(ctx, { room, encounterType, encounter });
   combat.devBurnMode = false;
+  combat.targeting = null;
   const container = createElement('div', 'combat');
   const sidebar = createElement('aside', 'combat__sidebar');
   const statsPanel = createElement('div', 'combat-sidebar__summary');
@@ -132,6 +205,7 @@ function createCombatExperience(ctx, { room, encounterType, encounter }) {
     'End Turn'
   );
   endTurnButton.addEventListener('click', () => {
+    cancelTargetSelection(combat);
     if (combat.turn === 'player' && combat.status === 'inProgress') {
       endPlayerTurn(combat);
     }
@@ -141,8 +215,34 @@ function createCombatExperience(ctx, { room, encounterType, encounter }) {
   const main = createElement('div', 'combat__main');
   const board = createElement('div', 'combat__board');
   const playerDisplay = createCombatantDisplay(combat.player, 'player');
-  const enemyDisplay = createCombatantDisplay(combat.enemy, 'enemy', encounter);
-  board.append(playerDisplay.container, enemyDisplay.container);
+  const playerGroup = createElement('div', 'combatant-group combatant-group--player');
+  playerGroup.appendChild(playerDisplay.container);
+
+  const enemyGroup = createElement('div', 'combatant-group combatant-group--enemies');
+  const enemyDisplays = new Map();
+  combat.enemies.forEach((enemy) => {
+    if (!enemy) {
+      return;
+    }
+    const enemyDisplay = createCombatantDisplay(enemy, 'enemy', enemy.sprite);
+    enemyDisplay.container.dataset.enemyId = enemy.id;
+    enemyDisplay.container.addEventListener('click', () => {
+      handleEnemyTargetSelection(combat, enemy.id);
+    });
+    enemyGroup.appendChild(enemyDisplay.container);
+    enemyDisplays.set(enemy.id, enemyDisplay);
+  });
+
+  if (enemyDisplays.size === 0) {
+    const placeholder = createElement(
+      'div',
+      'combatant-card combatant-card--enemy',
+      'No foes remain.'
+    );
+    enemyGroup.appendChild(placeholder);
+  }
+
+  board.append(playerGroup, enemyGroup);
   const floatLayer = createElement('div', 'combat__float-layer');
   const logElement = createCombatLogElement();
   main.append(board, floatLayer, logElement);
@@ -190,13 +290,25 @@ function createCombatExperience(ctx, { room, encounterType, encounter }) {
     playerPanel: playerDisplay.container,
     playerStats: playerDisplay.stats,
     playerStatuses: playerDisplay.statusList,
-    enemyPanel: enemyDisplay.container,
-    enemyStats: enemyDisplay.stats,
-    enemyStatuses: enemyDisplay.statusList,
+    enemyDisplays,
+    enemyGroup,
     footer,
     continueButton,
     devBurnButton: devBurnButton,
     devApButton,
+  };
+
+  combat.dom.getPanelForCombatant = (combatant) => {
+    if (!combatant) {
+      return null;
+    }
+    if (combatant.side === 'player') {
+      return combat.dom.playerPanel;
+    }
+    if (combatant.side === 'enemy') {
+      return combat.dom.enemyDisplays?.get(combatant.id)?.container || null;
+    }
+    return null;
   };
 
   setActiveCombat(combat);
@@ -237,12 +349,28 @@ function updateCombatUI(combat) {
     combat.dom.playerStats,
     combat.dom.playerStatuses
   );
-  updateCombatantPanel(
-    combat,
-    combat.enemy,
-    combat.dom.enemyStats,
-    combat.dom.enemyStatuses
-  );
+  if (Array.isArray(combat.enemies)) {
+    combat.enemies.forEach((enemy) => {
+      const display = combat.dom.enemyDisplays?.get(enemy.id);
+      if (!display) {
+        return;
+      }
+      updateCombatantPanel(combat, enemy, display.stats, display.statusList);
+      display.container.classList.toggle(
+        'combatant-card--defeated',
+        enemy.essence <= 0
+      );
+      const targeting = Boolean(combat.targeting);
+      display.container.classList.toggle(
+        'combatant-card--targetable',
+        targeting && enemy.essence > 0
+      );
+      display.container.classList.toggle(
+        'combatant-card--untargetable',
+        targeting && enemy.essence <= 0
+      );
+    });
+  }
 }
 
 function updateStatsSummary(combat) {
@@ -330,6 +458,14 @@ function updateActionButtons(combat) {
   if (!burnModeActive && combat.devBurnMode && !combat.ctx?.state?.devMode) {
     combat.devBurnMode = false;
   }
+  if (
+    combat.targeting &&
+    (!combat.actionSlots[combat.targeting.slotIndex] ||
+      !combat.actionSlots[combat.targeting.slotIndex]?.actionKey)
+  ) {
+    cancelTargetSelection(combat);
+    return;
+  }
   combat.actionSlots.forEach((slot, index) => {
     const button = createActionButton(combat, slot, index);
     bar.appendChild(button);
@@ -350,6 +486,7 @@ function createActionButton(combat, slot, index) {
     button.textContent = 'Unknown';
     return button;
   }
+  const requiresTarget = requiresEnemyTarget(action);
   const devDisabled = isDevEntryDisabled('action', action.key);
   const apCost = getActionApCost(combat, action);
   const essenceCost = getActionEssenceCost(combat, action);
@@ -407,8 +544,26 @@ function createActionButton(combat, slot, index) {
     button.title = `${action.name} — ${action.description}`;
   }
   if (canUse) {
-    button.addEventListener('click', () => performPlayerAction(combat, index));
+    if (requiresTarget) {
+      button.addEventListener('click', () => {
+        if (combat.targeting && combat.targeting.slotIndex === index) {
+          cancelTargetSelection(combat);
+        } else {
+          beginTargetSelection(combat, index, action);
+        }
+      });
+    } else {
+      button.addEventListener('click', () => {
+        cancelTargetSelection(combat);
+        performPlayerAction(combat, index);
+      });
+    }
   }
+  button.classList.toggle('action-button--requires-target', requiresTarget);
+  button.classList.toggle(
+    'action-button--targeting',
+    combat.targeting?.slotIndex === index
+  );
   return button;
 }
 

--- a/src/ui/dev-room-builder.js
+++ b/src/ui/dev-room-builder.js
@@ -28,23 +28,41 @@ function createOption(value, label) {
   return option;
 }
 
-function buildEncounterFromSprite(type, sprite) {
-  if (!sprite) {
+function buildEncounterFromSprite(type, sprites) {
+  const spriteList = Array.isArray(sprites)
+    ? sprites.filter(Boolean)
+    : sprites
+    ? [sprites]
+    : [];
+  if (spriteList.length === 0) {
     return null;
   }
-  const normalizedType = type || sprite.type || null;
+  const normalizedType = type || spriteList[0]?.type || null;
   const encounterType = normalizedType || "combat";
-  const kind =
-    encounterType === "merchant"
-      ? "merchant"
-      : encounterType === "boss"
-      ? "boss"
-      : "enemy";
+  const shouldAnimate = ANIMATED_ENCOUNTER_TYPES.has(encounterType);
+
+  if (encounterType === "combat" || encounterType === "elite" || encounterType === "boss") {
+    const enemies = spriteList.map((sprite) => ({ sprite }));
+    if (enemies.length === 0) {
+      return null;
+    }
+    return {
+      type: encounterType,
+      enemies,
+      sprite: enemies[0]?.sprite || null,
+      kind: encounterType === "boss" ? "boss" : "enemy",
+      animate: shouldAnimate,
+      enterDelay: 2000,
+    };
+  }
+
+  const sprite = spriteList[0];
+  const kind = encounterType === "merchant" ? "merchant" : "enemy";
   return {
     sprite,
     type: encounterType,
     kind,
-    animate: ANIMATED_ENCOUNTER_TYPES.has(encounterType),
+    animate: shouldAnimate,
     enterDelay: 2000,
   };
 }
@@ -246,7 +264,7 @@ export function createDevRoomBuilder(ctx, options = {}) {
 
   container.appendChild(panel);
 
-  let currentVariantSelect = null;
+  let currentVariantSelects = [];
 
   function updateLayoutDetails() {
     const selectedKey = layoutField.select.value;
@@ -266,7 +284,7 @@ export function createDevRoomBuilder(ctx, options = {}) {
   }
 
   function updateVariantField() {
-    currentVariantSelect = null;
+    currentVariantSelects = [];
     variantContainer.replaceChildren();
     const selectedType = typeField.select.value;
 
@@ -281,18 +299,24 @@ export function createDevRoomBuilder(ctx, options = {}) {
         );
         return;
       }
-      const { field, select } = createSelectField({
-        label: selectedType === "elite" ? "Elite Enemy" : "Enemy",
-        name: "enemy",
-        options: enemyOptions.map((enemy) => ({
-          value: enemy.key,
-          label: enemy.name,
-        })),
-        includeRandomOption: true,
-        randomLabel: "Random enemy",
-      });
-      variantContainer.appendChild(field);
-      currentVariantSelect = select;
+      const slotCount = selectedType === "elite" ? 2 : 1;
+      for (let i = 0; i < slotCount; i += 1) {
+        const { field, select } = createSelectField({
+          label:
+            slotCount === 1
+              ? "Enemy"
+              : `Enemy ${i + 1}`,
+          name: slotCount === 1 ? "enemy" : `enemy${i + 1}`,
+          options: enemyOptions.map((enemy) => ({
+            value: enemy.key,
+            label: enemy.name,
+          })),
+          includeRandomOption: true,
+          randomLabel: "Random enemy",
+        });
+        variantContainer.appendChild(field);
+        currentVariantSelects.push(select);
+      }
       return;
     }
 
@@ -307,18 +331,20 @@ export function createDevRoomBuilder(ctx, options = {}) {
         );
         return;
       }
-      const { field, select } = createSelectField({
-        label: "Boss",
-        name: "boss",
-        options: bossOptions.map((boss) => ({
-          value: boss.key,
-          label: boss.name,
-        })),
-        includeRandomOption: true,
-        randomLabel: "Random boss",
-      });
-      variantContainer.appendChild(field);
-      currentVariantSelect = select;
+      for (let i = 0; i < 3; i += 1) {
+        const { field, select } = createSelectField({
+          label: `Boss ${i + 1}`,
+          name: `boss${i + 1}`,
+          options: bossOptions.map((boss) => ({
+            value: boss.key,
+            label: boss.name,
+          })),
+          includeRandomOption: true,
+          randomLabel: "Random boss",
+        });
+        variantContainer.appendChild(field);
+        currentVariantSelects.push(select);
+      }
       return;
     }
 
@@ -344,7 +370,7 @@ export function createDevRoomBuilder(ctx, options = {}) {
         randomLabel: "Random merchant",
       });
       variantContainer.appendChild(field);
-      currentVariantSelect = select;
+      currentVariantSelects.push(select);
       return;
     }
 
@@ -370,7 +396,7 @@ export function createDevRoomBuilder(ctx, options = {}) {
         randomLabel: "Random event",
       });
       variantContainer.appendChild(field);
-      currentVariantSelect = select;
+      currentVariantSelects.push(select);
       return;
     }
 
@@ -436,24 +462,65 @@ export function createDevRoomBuilder(ctx, options = {}) {
     }
 
     if (selectedType === "event") {
-      const eventKey = currentVariantSelect?.value;
+      const eventKey = currentVariantSelects[0]?.value;
       if (eventKey) {
         optionsToUse.eventOptions = { eventKey };
       }
     } else {
-      const variantKey = currentVariantSelect?.value;
-      if (variantKey) {
-        let sprite = null;
-        if (selectedType === "combat" || selectedType === "elite") {
-          sprite = enemyMap.get(variantKey);
-        } else if (selectedType === "boss") {
-          sprite = bossMap.get(variantKey);
-        } else if (selectedType === "merchant") {
-          sprite = merchantMap.get(variantKey);
+      const selectionValues = currentVariantSelects
+        .map((select) => select?.value)
+        .filter((value) => typeof value === "string" && value);
+
+      const expectedCounts = {
+        combat: 1,
+        elite: 2,
+        boss: 3,
+        merchant: 1,
+      };
+
+      if (selectedType === "merchant" || selectedType === "combat") {
+        const expected = expectedCounts[selectedType] || 1;
+        if (selectionValues.length === expected) {
+          const map =
+            selectedType === "merchant" ? merchantMap : enemyMap;
+          const sprites = selectionValues
+            .map((value) => map.get(value))
+            .filter(Boolean);
+          const encounterOverride = buildEncounterFromSprite(
+            selectedType,
+            sprites
+          );
+          if (encounterOverride) {
+            optionsToUse.encounterOverride = encounterOverride;
+          }
         }
-        const encounterOverride = buildEncounterFromSprite(selectedType, sprite);
-        if (encounterOverride) {
-          optionsToUse.encounterOverride = encounterOverride;
+      } else if (selectedType === "elite") {
+        const expected = expectedCounts.elite;
+        if (selectionValues.length === expected) {
+          const sprites = selectionValues
+            .map((value) => enemyMap.get(value))
+            .filter(Boolean);
+          const encounterOverride = buildEncounterFromSprite(
+            selectedType,
+            sprites
+          );
+          if (encounterOverride) {
+            optionsToUse.encounterOverride = encounterOverride;
+          }
+        }
+      } else if (selectedType === "boss") {
+        const expected = expectedCounts.boss;
+        if (selectionValues.length === expected) {
+          const sprites = selectionValues
+            .map((value) => bossMap.get(value))
+            .filter(Boolean);
+          const encounterOverride = buildEncounterFromSprite(
+            selectedType,
+            sprites
+          );
+          if (encounterOverride) {
+            optionsToUse.encounterOverride = encounterOverride;
+          }
         }
       }
     }

--- a/src/ui/screens/corridor.js
+++ b/src/ui/screens/corridor.js
@@ -11,7 +11,7 @@ import {
   goToFoyer,
   goToRoom,
 } from "../../state/run.js";
-import { updateState } from "../../state/state.js";
+import { setEssenceValues, updateState } from "../../state/state.js";
 import { createElement } from "../dom.js";
 import { createDevRoomBuilder } from "../dev-room-builder.js";
 
@@ -260,13 +260,21 @@ const corridorScreen = {
         "Continue Down the Corridor"
       );
       continueButton.addEventListener("click", async () => {
+        const previousRefreshes = ctx.state.corridorRefreshes || 0;
+        const essenceLoss = 1 + previousRefreshes;
+        const currentEssence = ctx.state.playerEssence || 0;
+        const nextEssence = Math.max(0, currentEssence - essenceLoss);
+        setEssenceValues(nextEssence);
+        ctx.updateResources?.();
         const corridorRefreshes = (ctx.state.corridorRefreshes || 0) + 1;
         updateState({
           corridorRefreshes,
           lastRunScreen: "corridor",
         });
         await ctx.transitionTo("corridor", { refresh: true });
-        ctx.showToast("The corridor rearranges itself.");
+        ctx.showToast(
+          `The corridor rearranges itself, draining ${essenceLoss} essence.`
+        );
       });
       footer.appendChild(continueButton);
     }

--- a/styles.css
+++ b/styles.css
@@ -2317,6 +2317,24 @@ button {
   min-height: 220px;
 }
 
+.combatant-group {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.combatant-group--player {
+  flex: 0 0 auto;
+  justify-content: center;
+}
+
+.combatant-group--enemies {
+  flex: 1;
+}
+
 .combatant-card {
   flex: 1;
   display: flex;
@@ -2328,6 +2346,34 @@ button {
   border: 1px solid rgba(214, 179, 112, 0.25);
   background: rgba(8, 4, 2, 0.55);
   text-align: center;
+}
+
+.combatant-card--defeated {
+  opacity: 0.55;
+  filter: saturate(40%);
+}
+
+.combatant-card--targetable {
+  border-color: rgba(255, 77, 79, 0.65);
+  box-shadow: 0 0 0 2px rgba(255, 77, 79, 0.35);
+  cursor: pointer;
+}
+
+.combatant-card--untargetable {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.combat--targeting {
+  cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><circle cx='16' cy='16' r='8' fill='none' stroke='%23ff4d4f' stroke-width='2'/><line x1='16' y1='0' x2='16' y2='10' stroke='%23ff4d4f' stroke-width='2'/><line x1='16' y1='22' x2='16' y2='32' stroke='%23ff4d4f' stroke-width='2'/><line x1='0' y1='16' x2='10' y2='16' stroke='%23ff4d4f' stroke-width='2'/><line x1='22' y1='16' x2='32' y2='16' stroke='%23ff4d4f' stroke-width='2'/></svg>") 16 16, crosshair;
+}
+
+.combat--targeting .combatant-card--targetable {
+  cursor: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><circle cx='16' cy='16' r='8' fill='none' stroke='%23ff4d4f' stroke-width='2'/><line x1='16' y1='0' x2='16' y2='10' stroke='%23ff4d4f' stroke-width='2'/><line x1='16' y1='22' x2='16' y2='32' stroke='%23ff4d4f' stroke-width='2'/><line x1='0' y1='16' x2='10' y2='16' stroke='%23ff4d4f' stroke-width='2'/><line x1='22' y1='16' x2='32' y2='16' stroke='%23ff4d4f' stroke-width='2'/></svg>") 16 16, pointer;
+}
+
+.action-button--targeting {
+  box-shadow: 0 0 0 2px rgba(255, 77, 79, 0.35);
 }
 
 .combatant-card__avatar {


### PR DESCRIPTION
## Summary
- expand the combat engine, UI, and presentation layers to support multi-enemy encounters with per-target action selection
- update encounter generation and the developer room builder to populate multiple enemy slots for elite and boss rooms
- apply corridor refresh essence loss and adjust styles/layout to fit additional enemy sprites

## Testing
- manual testing

------
https://chatgpt.com/codex/tasks/task_e_68ea7df826f4832cad4de975150035d2